### PR TITLE
Improve fix for failing test on CI machine

### DIFF
--- a/src/LfMerge.Tests/Actions/ReceiveActionTests.cs
+++ b/src/LfMerge.Tests/Actions/ReceiveActionTests.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) 2016 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
-using NUnit.Framework;
-using LfMerge.Actions;
 using System.IO;
+using Chorus.VcsDrivers.Mercurial;
+using LfMerge.Actions;
+using NUnit.Framework;
 
 namespace LfMerge.Tests.Actions
 {
@@ -38,7 +39,7 @@ namespace LfMerge.Tests.Actions
 			var sut = LfMerge.Actions.Action.GetAction(ActionNames.Receive);
 
 			// Execute/Verify
-			Assert.That(() => sut.Run(lfProj), Throws.InstanceOf<Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException>());
+			Assert.That(() => sut.Run(lfProj), Throws.InstanceOf<RepositoryAuthorizationException>());
 
 			// Verify
 			Assert.That(lfProj.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.HOLD));

--- a/src/LfMerge.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Tests/TestEnvironment.cs
@@ -54,17 +54,20 @@ namespace LfMerge.Tests
 			bool registerProcessingStateDouble, bool fakeMongoConnectionShouldStoreData, string temporaryFolder)
 		{
 			ContainerBuilder containerBuilder = MainClass.RegisterTypes();
+			containerBuilder.RegisterType<LfMergeSettingsDouble>()
+				.WithParameter(new TypedParameter(typeof(string), temporaryFolder)).SingleInstance()
+				.As<LfMergeSettingsIni>();
+
+			if (fakeMongoConnectionShouldStoreData)
+				containerBuilder.RegisterType<MongoConnectionDoubleThatStoresData>().As<IMongoConnection>();
+			else
+				containerBuilder.RegisterType<MongoConnectionDouble>().As<IMongoConnection>();
+
 			if (registerSettingsModel)
 			{
-				containerBuilder.RegisterType<LfMergeSettingsDouble>().As<LfMergeSettingsIni>()
-					.WithParameter(new TypedParameter(typeof(string), temporaryFolder));
 				containerBuilder.RegisterType<InternetCloneSettingsModelDouble>().As<InternetCloneSettingsModel>();
 				containerBuilder.RegisterType<UpdateBranchHelperFlexDouble>().As<UpdateBranchHelperFlex>();
 				containerBuilder.RegisterType<FlexHelperDouble>().As<FlexHelper>();
-				if (fakeMongoConnectionShouldStoreData)
-					containerBuilder.RegisterType<MongoConnectionDoubleThatStoresData>().As<IMongoConnection>();
-				else
-					containerBuilder.RegisterType<MongoConnectionDouble>().As<IMongoConnection>();
 				containerBuilder.RegisterType<MongoProjectRecordFactoryDouble>().As<MongoProjectRecordFactory>();
 			}
 

--- a/src/LfMerge/Actions/ReceiveAction.cs
+++ b/src/LfMerge/Actions/ReceiveAction.cs
@@ -4,13 +4,13 @@ using System;
 using System.IO;
 using Autofac;
 using Chorus.Model;
+using Chorus.VcsDrivers.Mercurial;
 using LfMerge.FieldWorks;
 using LfMerge.Settings;
 using LibFLExBridgeChorusPlugin.Infrastructure;
 using LibTriboroughBridgeChorusPlugin;
 using LibTriboroughBridgeChorusPlugin.Infrastructure;
 using SIL.Progress;
-using SIL.Reporting;
 
 namespace LfMerge.Actions
 {
@@ -53,8 +53,15 @@ namespace LfMerge.Actions
 							project.State.SRState = ProcessingState.SendReceiveStates.HOLD;
 					}
 				}
-				catch (Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException)
+				catch (RepositoryAuthorizationException)
 				{
+					// We get this if the LD project doesn't exist or if authorization fails
+					project.State.SRState = ProcessingState.SendReceiveStates.HOLD;
+					throw;
+				}
+				catch (UnauthorizedAccessException)
+				{
+					// We get this if we can't create the local folder
 					project.State.SRState = ProcessingState.SendReceiveStates.HOLD;
 					throw;
 				}


### PR DESCRIPTION
One of the ReceiveActionTests failed on Jenkins that didn't fail
on my machine because /var/lib/languageforge was writable on the
CI machine and so the test went through a different code path.
This also revealed that the test wasn't quite correct in it's
expectations. This change improves the test and accounts for both
possible failure reasons.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/8)
<!-- Reviewable:end -->
