### PR TITLE
Initialize libpalaso's Logger for tests

### DIFF
--- a/environ
+++ b/environ
@@ -60,6 +60,9 @@ then
 	MONO_PATH="$(pkg-config --variable=assemblies_dir libfieldworks-fdo):$MONO_PATH"
 fi
 
+LD_LIBRARY_PATH="/usr/lib/fieldworks:${LD_LIBRARY_PATH}"
+FW_ROOTCODE=/usr/share/fieldworks
+
 MONO_TRACE_LISTENER="Console.Out"
 
 # if debugging for performance unset DEBUG_ENABLE_PTR_VALIDATION env var.
@@ -71,7 +74,8 @@ export \
 	MONO_PATH \
 	MONO_RUNTIME MONO_PREFIX MONO_GAC_PREFIX \
 	MONO_TRACE_LISTENER \
-	MONO_DEBUG MONO_ENV_OPTIONS
+	MONO_DEBUG MONO_ENV_OPTIONS \
+	FW_ROOTCODE
 
 # set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
 # incompatible with our version of Mercurial

--- a/src/LfMerge.Tests/LfMerge.Tests.csproj
+++ b/src/LfMerge.Tests/LfMerge.Tests.csproj
@@ -57,7 +57,6 @@
     </Reference>
     <Reference Include="FDO">
       <Package>libfieldworks-fdo</Package>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -82,19 +81,15 @@
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <Package>libfieldworks-fdo</Package>
-      <Private>True</Private>
     </Reference>
     <Reference Include="BasicUtils">
       <Package>libfieldworks-fdo</Package>
-      <Private>True</Private>
     </Reference>
     <Reference Include="CoreImpl">
       <Package>libfieldworks-fdo</Package>
-      <Private>True</Private>
     </Reference>
     <Reference Include="COMInterfaces">
       <Package>libfieldworks-fdo</Package>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/LfMerge.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Tests/TestEnvironment.cs
@@ -48,6 +48,8 @@ namespace LfMerge.Tests
 			{
 				CopySampleFwProject(testProjectCode);
 			}
+			SIL.Reporting.Logger.Init(Path.Combine(Directory.GetCurrentDirectory(), "LfMergeTests"),
+				false);
 		}
 
 		private static ContainerBuilder RegisterTypes(bool registerSettingsModel,
@@ -93,6 +95,7 @@ namespace LfMerge.Tests
 			LanguageForgeProjectAccessor.Reset();
 			_languageForgeServerFolder.Dispose();
 			Settings = null;
+			SIL.Reporting.Logger.ShutDown();
 		}
 
 		public string LanguageForgeFolder


### PR DESCRIPTION
This helps to get log messages that FDO might report.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/9)
<!-- Reviewable:end -->
