### PR TITLE
Remove hack to copy FixFwDataDll.dll

### DIFF
--- a/build/update-dependencies
+++ b/build/update-dependencies
@@ -5,7 +5,3 @@ pushd $script_dir/..
 popd
 rm $script_dir/LfMerge.files
 xbuild /t:DownloadDependencies $script_dir/LfMerge.proj
-# Quick-and-dirty (VERY dirty) hack since there's no Jenkins type available in LfMerge.dep
-echo "Now open your browser and download https://jenkins.lsdev.sil.org:45192/job/FieldWorks-Linux-any-LfMerge-debug/ws/fieldworks/Output/Debug/FixFwDataDll.dll"
-echo "(Can't download it automatically; you'll have to sign in to Jenkins first)"
-echo "Put the downloaded FixFwDataDll.dll file in LfMerge/lib/"

--- a/src/FixFwData/FixFwData.csproj
+++ b/src/FixFwData/FixFwData.csproj
@@ -68,7 +68,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="FixFwDataDll">
-      <HintPath>..\..\lib\FixFwDataDll.dll</HintPath>
+      <Package>lfmerge-fdo</Package>
     </Reference>
     <Reference Include="SIL.Linux.Logging">
       <HintPath>..\..\lib\SIL.Linux.Logging.dll</HintPath>


### PR DESCRIPTION
FixFwDataDll.dll is now part of the lfmerge-fdo package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/14)
<!-- Reviewable:end -->
