### PR TITLE
Adjust hgrc file when copying test project

### DIFF
--- a/src/LfMerge.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Tests/Actions/SynchronizeActionTests.cs
@@ -59,7 +59,7 @@ namespace LfMerge.Tests.Actions
 			_env = new TestEnvironment();
 			_env.Settings.CommitWhenDone = true;
 			_lfProject = LanguageForgeProject.Create(_env.Settings, testProjectCode);
-			FdoTestFixture.CopyFwProjectTo(testProjectCode, _env.Settings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, _env.Settings.WebWorkDirectory);
 
 			// Guids are named for the diffs for the modified test project
 			_testEntryGuid = Guid.Parse(testEntryGuidStr);
@@ -96,7 +96,7 @@ namespace LfMerge.Tests.Actions
 		public void SynchronizeAction_NoCloneNoChangedData_GlossUnchanged()
 		{
 			// Setup
-			FdoTestFixture.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
 
 			// Exercise
 			_sutSynchronize.Run(_lfProject);
@@ -115,7 +115,7 @@ namespace LfMerge.Tests.Actions
 		public void SynchronizeAction_LFDataChanged_GlossChanged()
 		{
 			// Setup
-			FdoTestFixture.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
 
 			_lfProject.IsInitialClone = true;
 			_transferFdoToMongo.Run(_lfProject);
@@ -166,7 +166,7 @@ namespace LfMerge.Tests.Actions
 		{
 			// Setup
 			_env.Settings.CommitWhenDone = false; // TODO: remove when multipara is no longer changing GUIDs when there are no changes. IJH 2016-03
-			FdoTestFixture.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
 			Directory.Move(Path.Combine(_lDSettings.WebWorkDirectory, modifiedTestProjectCode), LDProjectFolderPath);
 
 			_lfProject.IsInitialClone = true;
@@ -223,7 +223,7 @@ namespace LfMerge.Tests.Actions
 		public void SynchronizeAction_LFDataChangedLDDataChanged_LFWins()
 		{
 			//Setup
-			FdoTestFixture.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
 			Directory.Move(Path.Combine(_lDSettings.WebWorkDirectory, modifiedTestProjectCode), LDProjectFolderPath);
 
 			_lfProject.IsInitialClone = true;
@@ -259,7 +259,7 @@ namespace LfMerge.Tests.Actions
 		public void SynchronizeAction_LFDataDeleted_EntryRemoved()
 		{
 			// Setup
-			FdoTestFixture.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, _lDSettings.WebWorkDirectory);
 
 			_lfProject.IsInitialClone = true;
 			_transferFdoToMongo.Run(_lfProject);
@@ -299,7 +299,7 @@ namespace LfMerge.Tests.Actions
 		{
 			// Setup
 			_env.Settings.CommitWhenDone = false; // // TODO: remove when multipara is no longer changing GUIDs when there are no changes. DDW 2016-04
-			FdoTestFixture.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
 			Directory.Move(Path.Combine(_lDSettings.WebWorkDirectory, modifiedTestProjectCode), LDProjectFolderPath);
 
 			_lfProject.IsInitialClone = true;
@@ -348,7 +348,7 @@ namespace LfMerge.Tests.Actions
 		{
 			// Setup
 			//_env.Settings.CommitWhenDone = false; // TODO: Do we need this? remove when multipara is no longer changing GUIDs when there are no changes. DDW 2016-04
-			FdoTestFixture.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(modifiedTestProjectCode, _lDSettings.WebWorkDirectory);
 			Directory.Move(Path.Combine(_lDSettings.WebWorkDirectory, modifiedTestProjectCode), LDProjectFolderPath);
 
 			_lfProject.IsInitialClone = true;

--- a/src/LfMerge.Tests/Fdo/FdoTestBase.cs
+++ b/src/LfMerge.Tests/Fdo/FdoTestBase.cs
@@ -43,7 +43,7 @@ namespace LfMerge.Tests.Fdo
 				languageForgeServerFolder: LanguageForgeFolder
 			);
 			Settings = new LfMergeSettingsDouble(LanguageForgeFolder.Path);
-			CopyFwProjectTo(testProjectCode, Settings.DefaultProjectsDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, Settings.DefaultProjectsDirectory);
 			lfProj = LanguageForgeProject.Create(Settings, testProjectCode);
 		}
 
@@ -64,30 +64,6 @@ namespace LfMerge.Tests.Fdo
 			}
 		}
 
-		// TODO: Consider whether these two utility functions belong in a different class
-		public static void CopyFwProjectTo(string projectCode, string destDir)
-		{
-			string dataDir = Path.Combine(FindGitRepoRoot(), "data");
-			DirectoryUtilities.CopyDirectory(Path.Combine(dataDir, projectCode), destDir);
-			Console.WriteLine("Copied {0} to {1}", projectCode, destDir);
-		}
-
-		public static string FindGitRepoRoot(string startDir = null)
-		{
-			if (String.IsNullOrEmpty(startDir))
-				startDir = Directory.GetCurrentDirectory();
-			while (!Directory.Exists(Path.Combine(startDir, ".git")))
-			{
-				var di = new DirectoryInfo(startDir);
-				if (di.Parent == null) // We've reached the root directory
-				{
-					// Last-ditch effort: assume we're in output/Debug, even though we never found .git
-					return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "..", ".."));
-				}
-				startDir = Path.Combine(startDir, "..");
-			}
-			return Path.GetFullPath(startDir);
-		}
 	}
 
 	public class FdoTestBase

--- a/src/LfMerge.Tests/SampleData.cs
+++ b/src/LfMerge.Tests/SampleData.cs
@@ -21,7 +21,7 @@ namespace LfMerge.Tests
 			bsonProjectRecordData = BsonSerializer.Deserialize<BsonDocument>(jsonProjectRecordData);
 			bsonOptionListData = BsonSerializer.Deserialize<BsonDocument>(jsonOptionListData);
 			// Semantic domain data is found in $GITROOT/data/semantic-domains/semdom.json
-			string gitRoot = Fdo.FdoTestFixture.FindGitRepoRoot();
+			string gitRoot = TestEnvironment.FindGitRepoRoot();
 			string semDomFilename = Path.Combine(gitRoot, "data", "semantic-domains", "semdom.json");
 			string jsonSemDomData = File.ReadAllText(semDomFilename);
 			bsonSemDomData = BsonSerializer.Deserialize<BsonDocument>(jsonSemDomData);

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -217,10 +217,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <Target Name="AfterBuild">
-    <!-- Copy .mdb files for all files in output directory -->
+    <!-- Copy .mdb files for all files into output directory as well as ChorusMerge.exe -->
     <ItemGroup>
       <FilesInOutput Include="$(OutputPath)/*.*" />
       <FilesToCopy Include="@(FilesInOutput-&gt;'../../lib/%(Filename)%(Extension).mdb')" Condition="Exists('../../lib/%(Filename)%(Extension).mdb')" />
+      <FilesToCopy Include="../../lib/ChorusMerge.exe*"/>
+      <FilesToCopy Include="../../lib/LibChorus.dll*"/>
     </ItemGroup>
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
   </Target>


### PR DESCRIPTION
The hgrc file contains hard coded paths, so these need to be
adjusted to the current machine before running the tests. Correct
paths in hgrc are required so that Chorus can find e.g.
ChorusMerge.exe. This fixes or at least improves the otherwise
failing SynchronizeActionTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/18)
<!-- Reviewable:end -->
