### PR TITLE
Make unit tests more independent from mongodb

### DIFF
--- a/build/LfMerge.dep
+++ b/build/LfMerge.dep
@@ -40,14 +40,7 @@ Palaso.TestUtilities.dll*=>lib/
 L10NSharp.dll*=>lib/
 Ionic.Zip.dll*=>lib/
 Spart.dll*=>lib/
-
-
-[TC::Libpalaso_PalasoTrusty64LinuxLoggingContinuous]
-Name=palaso-trusty64-LinuxLogging Continuous
-RevisionName=lastSuccessful
-RevisionValue=latest.lastSuccessful
-Condition=Linux
-Path=SIL.Linux.Logging.dll*=>lib/
+SIL.Linux.Logging.dll*=>lib/
 icu.net.dll*=>lib/
 
 

--- a/build/LfMerge.dep
+++ b/build/LfMerge.dep
@@ -30,7 +30,7 @@ Path=Mercurial-x86_64.zip!**=>.
 
 
 [TC::PalasoPrecise64lfmergeContinuous]
-Name=palaso-precise64-lfmerge Continuous
+Name=palaso-trusty64-lfmerge Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux
@@ -76,8 +76,8 @@ L10NSharp.dll=>lib/
 L10NSharp.pdb=>lib/
 
 
-[TC::FLExBridgeLfmergePrecise64Continuous]
-Name=FLEx Bridge-lfmerge-Precise64-Continuous
+[TC::FLExBridgeLfmergeTrusty64Continuous]
+Name=FLEx Bridge-lfmerge-Trusty64-Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux

--- a/src/LfMerge.Tests/Fdo/DataConverters/ConvertFdoToMongoCustomFieldTests.cs
+++ b/src/LfMerge.Tests/Fdo/DataConverters/ConvertFdoToMongoCustomFieldTests.cs
@@ -4,10 +4,8 @@ using System;
 using System.Collections.Generic;
 using LfMerge.DataConverters;
 using LfMerge.LanguageForge.Config;
-using LfMerge.LanguageForge.Infrastructure;
 using LfMerge.Tests.Fdo;
 using MongoDB.Bson;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using SIL.FieldWorks.FDO;
 
@@ -21,14 +19,14 @@ namespace LfMerge.Tests.Fdo.DataConverters
 			// Setup
 			var lfProject = LanguageForgeProject.Create(_env.Settings, TestProjectCode);
 			var cache = lfProject.FieldWorksProject.Cache;
-			ConvertFdoToMongoCustomField converter = new ConvertFdoToMongoCustomField(cache, new Logging.SyslogLogger());
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
 			var entry = cache.ServiceLocator.GetObject(entryGuid) as ILexEntry;
 			Assert.That(entry, Is.Not.Null);
+			Dictionary<string, LfConfigFieldBase> lfCustomFieldList = new Dictionary<string, LfConfigFieldBase>();
+			ConvertFdoToMongoCustomField converter = new ConvertFdoToMongoCustomField(cache, new Logging.SyslogLogger());
 
 			// Exercise
-			Dictionary<string, LfConfigFieldBase>_lfCustomFieldList = new Dictionary<string, LfConfigFieldBase>();
-			BsonDocument customDataDocument = converter.GetCustomFieldsForThisCmObject(entry, "entry", _lfCustomFieldList);
+			BsonDocument customDataDocument = converter.GetCustomFieldsForThisCmObject(entry, "entry", lfCustomFieldList);
 
 			// Verify
 			List<string> expectedCustomFieldNames = new List<string>
@@ -42,46 +40,6 @@ namespace LfMerge.Tests.Fdo.DataConverters
 			CollectionAssert.AreEqual(customDataDocument[0].AsBsonDocument.Names, expectedCustomFieldNames);
 		}
 
-		[Test]
-		public void RunClass_listUsers_CanCallPhpClass()
-		{
-			// Setup
-			string className = "Api\\Model\\Command\\UserCommands";
-			string methodName = "listUsers";
-			var parameters = new List<Object>();
-
-			// Exercise
-			string output = PhpConnection.RunClass(className, methodName, parameters);
-
-			// Verify
-			var result = JsonConvert.DeserializeObject<Dictionary<string, Object>>(output);
-			Assert.That(output, Is.Not.Empty);
-			Assert.That(result["count"], Is.GreaterThan(0));
-		}
-
-		[Test, Explicit("Assumes PHP unit tests have been run once")]
-		public void RunClass_updateCustomFieldViews_ReturnsProjectId()
-		{
-			// Setup
-			string projectCode = "TestCode1";
-			string className = "Api\\Model\\Languageforge\\Lexicon\\Command\\LexProjectCommands";
-			string methodName = "updateCustomFieldViews";
-			var customFieldSpecs = new List<CustomFieldSpec>();
-			customFieldSpecs.Add(new CustomFieldSpec("customField_entry_testMultiPara", "OwningAtom"));
-			customFieldSpecs.Add(new CustomFieldSpec("customField_examples_testOptionList", "ReferenceAtom"));
-			var parameters = new List<Object>();
-			parameters.Add(projectCode);
-			parameters.Add(customFieldSpecs);
-
-			// Exercise
-			string output = PhpConnection.RunClass(className, methodName, parameters, true);
-
-			// Verify
-			var result = JsonConvert.DeserializeObject<string>(output);
-			Assert.That(output, Is.Not.Empty);
-			Assert.That(output, Is.Not.EqualTo("false"));
-			Assert.That(result, Is.Not.Empty);
-		}
 	}
 }
 

--- a/src/LfMerge.Tests/LanguageForge/Infrastructure/LanguageForgeProxyTests.cs
+++ b/src/LfMerge.Tests/LanguageForge/Infrastructure/LanguageForgeProxyTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using LfMerge.LanguageForge.Infrastructure;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Palaso.TestUtilities;
+
+namespace LfMerge.Tests.LanguageForge.Infrastructure
+{
+	[TestFixture]
+	[Category("IntegrationTests")]
+	public class LanguageForgeProxyTests
+	{
+		private const string testProjectCode = "testlangproj";
+		private const int originalNumOfFdoEntries = 63;
+		private TemporaryFolder LanguageForgeFolder;
+		private TestEnvironment _env;
+
+		[TestFixtureSetUp]
+		public void FixtureSetUp()
+		{
+			LanguageForgeFolder = new TemporaryFolder("FdoTestFixture");
+			_env = new TestEnvironment(
+				resetLfProjectsDuringCleanup: false,
+				languageForgeServerFolder: LanguageForgeFolder,
+				registerLfProxyMock: false
+			);
+		}
+
+		[TestFixtureTearDown]
+		public void FixtureTearDown()
+		{
+			try
+			{
+				LanguageForgeProjectAccessor.Reset(); // This disposes of lfProj
+				LanguageForgeFolder.Dispose();
+				_env.Dispose();
+			}
+			catch (Exception)
+			{
+				// This can happen if the objects already got disposed somewhere else.
+				// It doesn't really matter since we're in the process of doing cleanup anyways.
+				// So just ignore the exception.
+			}
+		}
+
+		[Test]
+		[Explicit("Requires users in the mongo database, i.e. requires setup languageforge database")]
+		public void ListUsers_CanCallPhpClass()
+		{
+			// Setup
+			var sut = new LanguageForgeProxy();
+
+			// Exercise
+			string output = sut.ListUsers();
+
+			// Verify
+			var result = JsonConvert.DeserializeObject<Dictionary<string, Object>>(output);
+			Assert.That(output, Is.Not.Empty);
+			Assert.That(result["count"], Is.GreaterThan(0));
+		}
+
+		[Test]
+		[Explicit("Assumes PHP unit tests have been run once")]
+		public void UpdateCustomFieldViews_ReturnsProjectId()
+		{
+			// Setup
+			var customFieldSpecs = new List<CustomFieldSpec>();
+			customFieldSpecs.Add(new CustomFieldSpec("customField_entry_testMultiPara", "OwningAtom"));
+			customFieldSpecs.Add(new CustomFieldSpec("customField_examples_testOptionList", "ReferenceAtom"));
+			var sut = new LanguageForgeProxy();
+
+			// Exercise
+			string output = sut.UpdateCustomFieldViews("TestCode1", customFieldSpecs, true);
+
+			// Verify
+			var result = JsonConvert.DeserializeObject<string>(output);
+			Assert.That(output, Is.Not.Empty);
+			Assert.That(output, Is.Not.EqualTo("false"));
+			Assert.That(result, Is.Not.Empty);
+		}
+	}
+}
+

--- a/src/LfMerge.Tests/LanguageForgeProxyMock.cs
+++ b/src/LfMerge.Tests/LanguageForgeProxyMock.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using LfMerge.LanguageForge.Infrastructure;
+using System.Collections.Generic;
+
+namespace LfMerge.Tests
+{
+	public class LanguageForgeProxyMock: ILanguageForgeProxy
+	{
+		#region ILanguageForgeProxy implementation
+
+		public string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs)
+		{
+			return UpdateCustomFieldViews(projectCode, customFieldSpecs, false);
+		}
+
+		public string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs, bool isTest)
+		{
+			return "true";
+		}
+
+		public string ListUsers()
+		{
+			return null;
+		}
+
+		#endregion
+	}
+}
+

--- a/src/LfMerge.Tests/LfMerge.Tests.csproj
+++ b/src/LfMerge.Tests/LfMerge.Tests.csproj
@@ -113,6 +113,8 @@
     <Compile Include="LanguageDepotMock.cs" />
     <Compile Include="Actions\SynchronizeActionTests.cs" />
     <Compile Include="Actions\EnsureCloneActionTests.cs" />
+    <Compile Include="LanguageForge\Infrastructure\LanguageForgeProxyTests.cs" />
+    <Compile Include="LanguageForgeProxyMock.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -125,4 +127,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />
+  <ItemGroup>
+    <Folder Include="LanguageForge\" />
+    <Folder Include="LanguageForge\Infrastructure\" />
+  </ItemGroup>
 </Project>

--- a/src/LfMerge/DataConverters/ConvertFdoToMongoCustomField.cs
+++ b/src/LfMerge/DataConverters/ConvertFdoToMongoCustomField.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autofac;
 using LfMerge.LanguageForge.Config;
 using LfMerge.LanguageForge.Infrastructure;
 using LfMerge.LanguageForge.Model;
@@ -10,10 +11,10 @@ using LfMerge.Logging;
 using MongoDB.Bson;
 using Newtonsoft.Json;
 using SIL.CoreImpl;
+using SIL.FieldWorks.Common.COMInterfaces;
 using SIL.FieldWorks.FDO;
 using SIL.FieldWorks.FDO.Application;
 using SIL.FieldWorks.FDO.Infrastructure;
-using SIL.FieldWorks.Common.COMInterfaces;
 
 namespace LfMerge.DataConverters
 {
@@ -78,12 +79,8 @@ namespace LfMerge.DataConverters
 				customFieldSpecs.Add(new CustomFieldSpec(lfCustomFieldName, _fieldNameToFieldType[lfCustomFieldName]));
 			}
 
-			string className = "Api\\Model\\Languageforge\\Lexicon\\Command\\LexProjectCommands";
-			string methodName = "updateCustomFieldViews";
-			var parameters = new List<Object>();
-			parameters.Add(project.ProjectCode);
-			parameters.Add(customFieldSpecs);
-			string output = PhpConnection.RunClass(className, methodName, parameters, isTest);
+			var lfproxy = MainClass.Container.Resolve<ILanguageForgeProxy>();
+			string output = lfproxy.UpdateCustomFieldViews(project.ProjectCode, customFieldSpecs, isTest);
 
 			if (string.IsNullOrEmpty(output) || output == "false")
 				return false;

--- a/src/LfMerge/LanguageForge/Infrastructure/ILanguageForgeProxy.cs
+++ b/src/LfMerge/LanguageForge/Infrastructure/ILanguageForgeProxy.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+
+namespace LfMerge.LanguageForge.Infrastructure
+{
+	public interface ILanguageForgeProxy
+	{
+		string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs);
+		string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs, bool isTest);
+
+		string ListUsers();
+	}
+}
+

--- a/src/LfMerge/LanguageForge/Infrastructure/LanguageForgeProxy.cs
+++ b/src/LfMerge/LanguageForge/Infrastructure/LanguageForgeProxy.cs
@@ -10,14 +10,38 @@ using Newtonsoft.Json;
 
 namespace LfMerge.LanguageForge.Infrastructure
 {
-	public static class PhpConnection
+	public class LanguageForgeProxy: ILanguageForgeProxy
 	{
-		public static string RunClass(string className, string methodName, List<Object> parameters)
+		public string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs)
+		{
+			return UpdateCustomFieldViews(projectCode, customFieldSpecs, false);
+		}
+
+		public string UpdateCustomFieldViews(string projectCode, List<CustomFieldSpec> customFieldSpecs, bool isTest)
+		{
+			const string className = "Api\\Model\\Languageforge\\Lexicon\\Command\\LexProjectCommands";
+			const string methodName = "updateCustomFieldViews";
+			var parameters = new List<Object>();
+			parameters.Add(projectCode);
+			parameters.Add(customFieldSpecs);
+			return RunClass(className, methodName, parameters, isTest);
+		}
+
+		public string ListUsers()
+		{
+			const string className = "Api\\Model\\Command\\UserCommands";
+			const string methodName = "listUsers";
+			var parameters = new List<Object>();
+
+			return RunClass(className, methodName, parameters);
+		}
+
+		private static string RunClass(string className, string methodName, List<Object> parameters)
 		{
 			return RunClass(className, methodName, parameters, false);
 		}
 
-		public static string RunClass(string className, string methodName, List<Object> parameters, bool isTest)
+		private static string RunClass(string className, string methodName, List<Object> parameters, bool isTest)
 		{
 			var runClassParameters = new RunClassParameters(className, methodName, parameters);
 			runClassParameters.isTest = isTest;
@@ -49,7 +73,6 @@ namespace LfMerge.LanguageForge.Infrastructure
 
 			return output;
 		}
-
 	}
 }
 

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -171,11 +171,12 @@
     <Compile Include="Logging\SyslogProgress.cs" />
     <Compile Include="LanguageForge\Model\LfParagraph.cs" />
     <Compile Include="LanguageForge\Model\LfMultiParagraph.cs" />
-    <Compile Include="LanguageForge\Infrastructure\PhpConnection.cs" />
     <Compile Include="LanguageForge\Infrastructure\RunClassParameters.cs" />
     <Compile Include="LanguageForge\Infrastructure\CustomFieldSpec.cs" />
     <Compile Include="Actions\EnsureCloneAction.cs" />
     <Compile Include="Actions\Infrastructure\LfMergeBridgeServices.cs" />
+    <Compile Include="LanguageForge\Infrastructure\LanguageForgeProxy.cs" />
+    <Compile Include="LanguageForge\Infrastructure\ILanguageForgeProxy.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\BuildDependencyTasks.0.2.5.0\build\BuildDependencyTasks.targets" Condition="Exists('..\..\packages\BuildDependencyTasks.0.2.5.0\build\BuildDependencyTasks.targets')" />

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -7,13 +7,13 @@ using System.Linq;
 using Autofac;
 using LfMerge.Actions;
 using LfMerge.Actions.Infrastructure;
+using LfMerge.LanguageForge.Infrastructure;
 using LfMerge.Logging;
 using LfMerge.MongoConnector;
 using LfMerge.Queues;
 using LfMerge.Settings;
 using Palaso.IO.FileLock;
 using Palaso.Progress;
-using SIL.FieldWorks.FDO;
 
 
 namespace LfMerge
@@ -35,6 +35,7 @@ namespace LfMerge
 			containerBuilder.RegisterType<MongoConnection>().SingleInstance().As<IMongoConnection>().ExternallyOwned();
 			containerBuilder.RegisterType<MongoProjectRecordFactory>().AsSelf();
 			containerBuilder.RegisterType<SyslogProgress>().As<IProgress>();
+			containerBuilder.RegisterType<LanguageForgeProxy>().As<ILanguageForgeProxy>();
 			Actions.Action.Register(containerBuilder);
 			Queue.Register(containerBuilder);
 			return containerBuilder;


### PR DESCRIPTION
- move code to access PHP in a proxy class
- make unit tests use of a mock proxy
- move integration tests that test accessing the PHP code to separate
  test class

This allows to run the unit tests without having mongodb and PHP
installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/22)
<!-- Reviewable:end -->
