### PR TITLE
Fix Mercurial in package

### DIFF
--- a/build/LfMerge.proj
+++ b/build/LfMerge.proj
@@ -95,7 +95,7 @@
 
 	<Target Name="PrepareSource" DependsOnTargets="RestorePackages;DownloadDependencies">
 		<!-- This target gets called before building the source package -->
-		<RemoveDir Directories="$(RootDir)/Downloads"/>
+		<RemoveDir Directories="$(RootDir)/Mercurial"/>
 	</Target>
 
 	<Target Name="Compile" DependsOnTargets="RestorePackages;DownloadDependencies">


### PR DESCRIPTION
When building the source package all *.so files get removed. This
breaks Mercurial. So we now keep the Mercurial*.zip file and remove
the extracted files.

NOTE: this is a partial fix. It will need another change in `rules` or `LfMerge.proj` to extract the zip file.