### PR TITLE
Set username "Language Forge" instead of "www-data"

### DIFF
--- a/src/LfMerge.Tests/Actions/EnsureCloneActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Tests/Actions/EnsureCloneActionBridgeIntegrationTests.cs
@@ -175,6 +175,8 @@ namespace LfMerge.Tests.Actions
 			// Verify
 			Assert.That(_env.Logger.GetErrors(), Is.Empty);
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
+			Assert.That(MercurialTestHelper.GetUsernameFromHgrc(_lfProject.ProjectDir),
+				Is.EqualTo("Language Forge"));
 		}
 
 		/// <summary>

--- a/src/LfMerge.Tests/MercurialTestHelper.cs
+++ b/src/LfMerge.Tests/MercurialTestHelper.cs
@@ -100,6 +100,15 @@ namespace LfMerge.Tests
 		{
 			return RunHgCommand(repoPath, "tip --template \"{node|short}\"");
 		}
+
+		public static string GetUsernameFromHgrc(string repoPath)
+		{
+			var hgrc = Path.Combine(repoPath, ".hg", "hgrc");
+			var parser = new IniDataParser();
+			var iniData = parser.Parse(File.ReadAllText(hgrc));
+			return iniData["ui"]["username"];
+		}
+
 	}
 }
 

--- a/src/LfMerge/Actions/EnsureCloneAction.cs
+++ b/src/LfMerge/Actions/EnsureCloneAction.cs
@@ -152,7 +152,8 @@ namespace LfMerge.Actions
 				{ "fullPathToProject", projectFolderPath },
 				{ "languageDepotRepoName", project.LanguageDepotProject.Identifier },
 				{ "fdoDataModelVersion", FdoCache.ModelVersion },
-				{ "languageDepotRepoUri", chorusHelper.GetSyncUri(project) }
+				{ "languageDepotRepoUri", chorusHelper.GetSyncUri(project) },
+				{ "user", "Language Forge"}
 			};
 			return LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Clone", Progress, options,
 				out cloneResult);


### PR DESCRIPTION
This is done by setting the username in the hgrc file when cloning
the repo. Note that this won't change the name for projects that
were clone prior to this change.

This change requires a change in flexbridge (https://github.com/sillsdev/flexbridge/pull/102).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/25)
<!-- Reviewable:end -->
