### PR TITLE
Don't skip Sync step if webwork folder is missing

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/EnsureCloneActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/EnsureCloneActionBridgeIntegrationTests.cs
@@ -5,6 +5,7 @@ using Autofac;
 using LfMerge.Core.Actions;
 using LfMerge.Core.Actions.Infrastructure;
 using LfMerge.Core.Logging;
+using LfMerge.Core.MongoConnector;
 using LfMerge.Core.Settings;
 using NUnit.Framework;
 using Palaso.TestUtilities;
@@ -25,8 +26,8 @@ namespace LfMerge.Core.Tests.Actions
 	{
 		private class EnsureCloneActionWithoutMongo: EnsureCloneAction
 		{
-			public EnsureCloneActionWithoutMongo(LfMergeSettings settings, ILogger logger)
-				: base(settings, logger)
+			public EnsureCloneActionWithoutMongo(LfMergeSettings settings, ILogger logger, MongoProjectRecordFactory factory)
+				: base(settings, logger, factory)
 			{
 			}
 
@@ -41,6 +42,7 @@ namespace LfMerge.Core.Tests.Actions
 		private LfMergeSettings _lDSettings;
 		private TemporaryFolder _languageDepotFolder;
 		private LanguageForgeProject _lfProject;
+		private MongoProjectRecordFactoryDouble _mongoProjectRecordFactory;
 		private EnsureCloneAction _EnsureCloneAction;
 		private const string TestLangProj = "testlangproj";
 
@@ -55,7 +57,8 @@ namespace LfMerge.Core.Tests.Actions
 				Path.Combine(_lDSettings.WebWorkDirectory, TestContext.CurrentContext.Test.Name, TestLangProj);
 			Directory.CreateDirectory(LanguageDepotMock.ProjectFolderPath);
 			_lfProject = LanguageForgeProject.Create(TestLangProj);
-			_EnsureCloneAction = new EnsureCloneActionWithoutMongo(_env.Settings, _env.Logger);
+			_mongoProjectRecordFactory = MainClass.Container.Resolve<LfMerge.Core.MongoConnector.MongoProjectRecordFactory>() as MongoProjectRecordFactoryDouble;
+			_EnsureCloneAction = new EnsureCloneActionWithoutMongo(_env.Settings, _env.Logger, _mongoProjectRecordFactory);
 			LanguageDepotMock.Server = new MercurialServer(LanguageDepotMock.ProjectFolderPath);
 		}
 

--- a/src/LfMerge.Core.Tests/Actions/EnsureCloneActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/EnsureCloneActionTests.cs
@@ -2,6 +2,8 @@
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;
+using Autofac;
+using LfMerge.Core.MongoConnector;
 using NUnit.Framework;
 
 namespace LfMerge.Core.Tests.Actions
@@ -15,6 +17,7 @@ namespace LfMerge.Core.Tests.Actions
 	{
 		private TestEnvironment _env;
 		private string _projectCode;
+		private MongoProjectRecordFactoryDouble _mongoProjectRecordFactory;
 
 		[SetUp]
 		public void Setup()
@@ -25,6 +28,7 @@ namespace LfMerge.Core.Tests.Actions
 			Directory.CreateDirectory(_projectDir);
 			// Making a stub file so Chorus model.TargetLocationIsUnused will be false
 			File.Create(Path.Combine(_projectDir, "stub"));
+			_mongoProjectRecordFactory = MainClass.Container.Resolve<MongoProjectRecordFactory>() as MongoProjectRecordFactoryDouble;
 		}
 
 		[TearDown]
@@ -45,7 +49,7 @@ namespace LfMerge.Core.Tests.Actions
 			var lfProject = LanguageForgeProject.Create(nonExistingProjectCode);
 
 			// Execute
-			Assert.That( () => new EnsureCloneActionDouble(_env.Settings, _env.Logger, false).Run(lfProject),
+			Assert.That( () => new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory, false).Run(lfProject),
 				Throws.Exception.TypeOf(Type.GetType("Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException")));
 
 			// Verify
@@ -66,7 +70,7 @@ namespace LfMerge.Core.Tests.Actions
 				"Clone of project shouldn't exist");
 
 			// Execute
-			new EnsureCloneActionDouble(_env.Settings, _env.Logger).Run(lfProject);
+			new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory).Run(lfProject);
 
 			// Verify
 			Assert.That(lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.CLONED),
@@ -93,7 +97,7 @@ namespace LfMerge.Core.Tests.Actions
 				"Clone of project shouldn't exist");
 
 			// Execute
-			new EnsureCloneActionDouble(_env.Settings, _env.Logger).Run(lfProject);
+			new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory).Run(lfProject);
 
 			// Verify
 			Assert.That(lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.CLONED),
@@ -116,10 +120,10 @@ namespace LfMerge.Core.Tests.Actions
 			Assert.That(Directory.Exists(Path.Combine(projectDir, ".hg")), Is.False,
 				"Clone of project shouldn't exist");
 			var me = Directory.GetFiles(projectDir, "*.*", SearchOption.AllDirectories).Length == 0;
-			Console.WriteLine("{0}", me); 
+			Console.WriteLine("{0}", me);
 
 			// Execute
-			new EnsureCloneActionDouble(_env.Settings, _env.Logger).Run(lfProject);
+			new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory).Run(lfProject);
 
 			// Verify
 			Assert.That(Directory.Exists(Path.Combine(projectDir, ".hg")), Is.False,
@@ -141,7 +145,7 @@ namespace LfMerge.Core.Tests.Actions
 				"Clone of project shouldn't exist");
 
 			// Execute
-			new EnsureCloneActionDouble(_env.Settings, _env.Logger).Run(lfProject);
+			new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory).Run(lfProject);
 
 			// Verify
 			Assert.That(Directory.Exists(Path.Combine(projectDir, ".hg")), Is.True,
@@ -161,7 +165,7 @@ namespace LfMerge.Core.Tests.Actions
 				"Clone of project shouldn't exist yet");
 
 			// Execute
-			new EnsureCloneActionDouble(_env.Settings, _env.Logger).Run(lfProject);
+			new EnsureCloneActionDouble(_env.Settings, _env.Logger, _mongoProjectRecordFactory).Run(lfProject);
 
 			// Verify
 			Assert.That(Directory.Exists(Path.Combine(projectDir, ".hg")), Is.True,

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -146,7 +146,7 @@ namespace LfMerge.Core.Tests.Actions
 			// do it indirectly by re-cloning the repo from LD and checking the new clone.
 			_lfProject.FieldWorksProject.Dispose();
 			Directory.Delete(_lfProject.ProjectDir, true);
-			var ensureClone = new EnsureCloneAction(_env.Settings, _env.Logger);
+			var ensureClone = new EnsureCloneAction(_env.Settings, _env.Logger, _recordFactory);
 			ensureClone.Run(_lfProject);
 			return GetGlossFromFdo(testEntryGuid, expectedSensesCount);
 		}

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -321,6 +321,7 @@ namespace LfMerge.Core.Tests
 				LanguageCode = "fr",
 				ProjectCode = project.ProjectCode,
 				ProjectName = project.ProjectCode,
+				SendReceiveProjectIdentifier = null,
 				Config = sampleConfig
 			};
 		}
@@ -352,8 +353,9 @@ namespace LfMerge.Core.Tests
 	{
 		private readonly bool _projectExists;
 
-		public EnsureCloneActionDouble(LfMergeSettings settings, ILogger logger, bool projectExists = true):
-			base(settings, logger)
+		public EnsureCloneActionDouble(LfMergeSettings settings, ILogger logger,
+			MongoProjectRecordFactory projectRecordFactory, bool projectExists = true):
+			base(settings, logger, projectRecordFactory)
 		{
 			_projectExists = projectExists;
 		}

--- a/src/LfMerge.Core/MongoConnector/MongoProjectRecord.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoProjectRecord.cs
@@ -21,12 +21,21 @@ namespace LfMerge.Core.MongoConnector
 		public string ProjectName { get; set; }
 		public DateTime? LastSyncedDate { get; set; }
 		public LfProjectConfig Config { get; set; }
+		// public SendReceiveProjectRecord SendReceiveProject { get; set; }  // Not yet needed; uncomment if we do need it
+		public string SendReceiveProjectIdentifier { get; set; }
 
 		public MongoProjectRecord()
 		{
 			InputSystems = new Dictionary<string, LfInputSystemRecord>();
 		}
 	}
+
+	// public class SendReceiveProjectRecord
+	// {
+	// 	public string Name { get; set; }
+	// 	public string Repository { get; set; }
+	// 	public string Role { get; set; }
+	// }
 }
 
 /* Mongo project records have the following fields, but we don't need to map all of them:


### PR DESCRIPTION
There's a scenario which could result in loss of user data that had been stored in Mongo:

1. User makes changes in LF.
2. While he's making those changes, the project's webwork folder (containing the Mercurial repo) gets deleted somehow.
3. User pushes Send/Receive button.
4. LfMerge sees no Mercurial repo, and thinks this is an initial clone.
5. Because this is an initial clone, TransferMongoToFdo is skipped.
6. Result: the TransferFdoToMongo step overwrites the user's changes in LF, which are permanently lost since Mongo doesn't keep previous versions of overwritten data.

To avoid this scenario, if the project's Mercurial repo is missing, we also check whether the Mongo database contains a project record for this project. If that record exists and contains a known piece of data (a Send/Receive project identifier, which should exist for every such project), then it's a real project (as opposed to a "ghost" left behind from project deletion) and we should NOT skip the Mongo->Fdo step, lest user data from LF be lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/35)
<!-- Reviewable:end -->
