### PR TITLE
Command line improvements for automated tests

### DIFF
--- a/src/LfMerge.Core.Tests/Fdo/FdoTestBase.cs
+++ b/src/LfMerge.Core.Tests/Fdo/FdoTestBase.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2016 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
 using Autofac;
 using LfMerge.Core.Actions;
 using LfMerge.Core.DataConverters;
@@ -12,8 +14,6 @@ using Palaso.TestUtilities;
 using NUnit.Framework;
 using SIL.FieldWorks.FDO;
 using SIL.FieldWorks.FDO.Infrastructure;
-using System;
-using System.Collections.Generic;
 
 namespace LfMerge.Core.Tests.Fdo
 {
@@ -45,7 +45,7 @@ namespace LfMerge.Core.Tests.Fdo
 				languageForgeServerFolder: LanguageForgeFolder
 			);
 			Settings = new LfMergeSettingsDouble(LanguageForgeFolder.Path);
-			TestEnvironment.CopyFwProjectTo(testProjectCode, Settings.DefaultProjectsDirectory);
+			TestEnvironment.CopyFwProjectTo(testProjectCode, Settings.FdoDirectorySettings.DefaultProjectsDirectory);
 			lfProj = LanguageForgeProject.Create(testProjectCode);
 		}
 

--- a/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
+++ b/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
@@ -33,9 +33,9 @@ namespace LfMerge.Core.Tests
 			var sut = new LfMergeSettingsAccessor();
 			sut.Initialize(Path.GetTempPath(), "projects", "templates");
 
-			Assert.That(sut.ProjectsDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "projects")));
-			Assert.That(sut.DefaultProjectsDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "projects")));
-			Assert.That(sut.TemplateDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "templates")));
+			Assert.That(sut.FdoDirectorySettings.ProjectsDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "projects")));
+			Assert.That(sut.FdoDirectorySettings.DefaultProjectsDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "projects")));
+			Assert.That(sut.FdoDirectorySettings.TemplateDirectory, Is.EqualTo(Path.Combine(Path.GetTempPath(), "templates")));
 		}
 
 		[Test]
@@ -44,9 +44,9 @@ namespace LfMerge.Core.Tests
 			var sut = new LfMergeSettingsAccessor();
 			sut.Initialize(Path.GetTempPath(), "/projects", "/foo/templates");
 
-			Assert.That(sut.ProjectsDirectory, Is.EqualTo("/projects"));
-			Assert.That(sut.DefaultProjectsDirectory, Is.EqualTo("/projects"));
-			Assert.That(sut.TemplateDirectory, Is.EqualTo("/foo/templates"));
+			Assert.That(sut.FdoDirectorySettings.ProjectsDirectory, Is.EqualTo("/projects"));
+			Assert.That(sut.FdoDirectorySettings.DefaultProjectsDirectory, Is.EqualTo("/projects"));
+			Assert.That(sut.FdoDirectorySettings.TemplateDirectory, Is.EqualTo("/foo/templates"));
 		}
 
 		[Test]

--- a/src/LfMerge.Core.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/TestEnvironment.cs
@@ -46,8 +46,8 @@ namespace LfMerge.Core.Tests
 				registerLfProxyMock).Build();
 			Settings = MainClass.Container.Resolve<LfMergeSettings>();
 			MainClass.Logger = MainClass.Container.Resolve<ILogger>();
-			Directory.CreateDirectory(Settings.ProjectsDirectory);
-			Directory.CreateDirectory(Settings.TemplateDirectory);
+			Directory.CreateDirectory(Settings.FdoDirectorySettings.ProjectsDirectory);
+			Directory.CreateDirectory(Settings.FdoDirectorySettings.TemplateDirectory);
 			Directory.CreateDirectory(Settings.StateDirectory);
 			_mongoConnection = MainClass.Container.Resolve<IMongoConnection>() as MongoConnectionDouble;
 		}
@@ -118,7 +118,7 @@ namespace LfMerge.Core.Tests
 			// get { return Path.Combine(_languageForgeServerFolder.Path, "webwork"); }
 			// Should get this from Settings object, but unfortunately we have to resolve this
 			// *before* the Settings object is available.
-			get { return LangForgeDirFinder.ProjectsDirectory; }
+			get { return LangForgeDirFinder.FdoDirectorySettings.ProjectsDirectory; }
 		}
 
 		public LfMergeSettings LangForgeDirFinder

--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -4,6 +4,7 @@ using System;
 using Autofac;
 using Palaso.Network;
 using SIL.FieldWorks.FDO;
+using LfMerge.Core.Settings;
 
 namespace LfMerge.Core.Actions.Infrastructure
 {
@@ -11,6 +12,10 @@ namespace LfMerge.Core.Actions.Infrastructure
 	{
 		public virtual string GetSyncUri(ILfProject project)
 		{
+			var settings = MainClass.Container.Resolve<LfMergeSettings>();
+			if (!string.IsNullOrEmpty(settings.LanguageDepotRepoUri))
+				return settings.LanguageDepotRepoUri;
+
 			var uriBldr = new UriBuilder(project.LanguageDepotProjectUri);
 			uriBldr.UserName = "x";
 			uriBldr.Password = "x";

--- a/src/LfMerge.Core/FieldWorks/FwProject.cs
+++ b/src/LfMerge.Core/FieldWorks/FwProject.cs
@@ -22,7 +22,7 @@ namespace LfMerge.Core.FieldWorks
 
 		public FwProject(LfMergeSettings settings, string database)
 		{
-			_project = new ProjectIdentifier(settings, database);
+			_project = new ProjectIdentifier(settings.FdoDirectorySettings, database);
 			_fdoUi = new ConsoleFdoUi(_progress.SynchronizeInvoke);
 			Cache = TryGetFdoCache();
 			if (Cache != null)

--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -64,7 +64,7 @@ namespace LfMerge.Core
 		}
 
 		public static void StartLfMerge(string projectCode, ActionNames action,
-			string modelVersion, bool allowFreshClone)
+			string modelVersion, bool allowFreshClone, string configDir = null)
 		{
 			// Call the correct model version specific LfMerge executable
 			if (string.IsNullOrEmpty(modelVersion))
@@ -86,6 +86,8 @@ namespace LfMerge.Core
 				argsBldr.Append(" --clone");
 			if (FwProject.AllowDataMigration)
 				argsBldr.Append(" --migrate");
+			if (!string.IsNullOrEmpty(configDir))
+				argsBldr.AppendFormat(" --config \"{0}\"", configDir);
 			startInfo.Arguments = argsBldr.ToString();
 			startInfo.CreateNoWindow = true;
 			startInfo.ErrorDialog = false;

--- a/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
@@ -16,6 +16,7 @@ MongoDatabaseNamePrefix = sf_
 VerboseProgress = false
 PhpSourcePath = /var/www/languageforge.org/htdocs
 ";
+		// optional, usually not set: LanguageDepotRepoUri =
 	}
 }
 

--- a/src/LfMerge/Options.cs
+++ b/src/LfMerge/Options.cs
@@ -27,6 +27,9 @@ namespace LfMerge
 		[Option("migrate", HelpText = "Allow data migration")]
 		public bool AllowDataMigration { get; set; }
 
+		[Option("config", HelpText = "Alternate location of the 'sendreceive.conf' configuration file")]
+		public string ConfigDir { get; set; }
+
 		[HelpOption('h', "help")]
 		public string GetUsage()
 		{

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -9,6 +9,7 @@ using LfMerge.Core.Actions;
 using LfMerge.Core.Actions.Infrastructure;
 using LfMerge.Core.FieldWorks;
 using LfMerge.Core.MongoConnector;
+using LfMerge.Core.Settings;
 
 namespace LfMerge
 {
@@ -23,6 +24,9 @@ namespace LfMerge
 
 			MainClass.Logger.Notice("LfMerge (database {0}) starting with args: {1}",
 				MainClass.ModelVersion, string.Join(" ", args));
+
+			if (!string.IsNullOrEmpty(options.ConfigDir))
+				LfMergeSettings.ConfigDir = options.ConfigDir;
 
 			FwProject.AllowDataMigration = options.AllowDataMigration;
 
@@ -50,7 +54,7 @@ namespace LfMerge
 			if (!string.IsNullOrEmpty(differentModelVersion))
 			{
 				MainClass.StartLfMerge(options.ProjectCode, options.CurrentAction,
-					differentModelVersion, false);
+					differentModelVersion, false, options.ConfigDir);
 			}
 
 			MainClass.Logger.Notice("LfMerge-{0} finished", MainClass.ModelVersion);

--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -45,7 +45,7 @@ namespace LfMerge.QueueManager
 					var clonedQueue = queue.QueuedProjects.ToList();
 					foreach (var projectCode in clonedQueue)
 					{
-						var projectPath = Path.Combine(settings.ProjectsDirectory,
+						var projectPath = Path.Combine(settings.FdoDirectorySettings.ProjectsDirectory,
 							projectCode, string.Format("{0}{1}", projectCode,
 								FdoFileHelper.ksFwDataXmlFileExtension));
 						var modelVersion = FwProject.GetModelVersion(projectPath);


### PR DESCRIPTION
- allow to specify alternative config directory by passing --config
  on command line
- allow to specify alternative LanguageDepot URL in config file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/36)
<!-- Reviewable:end -->
