### PR TITLE
Dequeue projects before running LfMerge

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -63,7 +63,7 @@ namespace LfMerge.Core
 			return containerBuilder;
 		}
 
-		public static void StartLfMerge(string projectCode, ActionNames action,
+		public static int StartLfMerge(string projectCode, ActionNames action,
 			string modelVersion, bool allowFreshClone, string configDir = null)
 		{
 			// Call the correct model version specific LfMerge executable
@@ -98,6 +98,7 @@ namespace LfMerge.Core
 				using (var process = Process.Start(startInfo))
 				{
 					process.WaitForExit();
+					return process.ExitCode;
 				}
 			}
 			catch (Exception e)
@@ -106,6 +107,7 @@ namespace LfMerge.Core
 					"{0}-{1}: Unhandled exception trying to start '{2}' '{3}' in '{4}'\n{5}",
 					Assembly.GetEntryAssembly().GetName().Name, ModelVersion, startInfo.FileName,
 					startInfo.Arguments, startInfo.WorkingDirectory, e);
+				return 1; // TODO: Decide what error code to return for unhandled exceptions
 			}
 		}
 

--- a/src/LfMerge/ErrorCode.cs
+++ b/src/LfMerge/ErrorCode.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2011-2017 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+namespace LfMerge
+{
+	public enum ErrorCode
+	{
+		NoError = 0,
+		GeneralError = 1,  // Use this if there's no need for a specific error code
+		InvalidOptions = 2,
+		// TODO: Any other specific error codes we might want? FailedClone, LanguageDepotAuthenticationFailed, ...?
+	}
+}

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -105,6 +105,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ErrorCode.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Options.cs" />

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -16,11 +16,12 @@ namespace LfMerge
 	public class Program
 	{
 		[STAThread]
-		public static void Main(string[] args)
+		public static int Main(string[] args)
 		{
+			int result = (int)ErrorCode.NoError;
 			var options = Options.ParseCommandLineArgs(args);
 			if (options == null)
-				return;
+				return (int)ErrorCode.InvalidOptions;
 
 			MainClass.Logger.Notice("LfMerge (database {0}) starting with args: {1}",
 				MainClass.ModelVersion, string.Join(" ", args));
@@ -34,7 +35,7 @@ namespace LfMerge
 			try
 			{
 				if (!MainClass.CheckSetup())
-					return;
+					return (int)ErrorCode.GeneralError;
 
 				MongoConnection.Initialize();
 
@@ -53,11 +54,12 @@ namespace LfMerge
 
 			if (!string.IsNullOrEmpty(differentModelVersion))
 			{
-				MainClass.StartLfMerge(options.ProjectCode, options.CurrentAction,
+				result = MainClass.StartLfMerge(options.ProjectCode, options.CurrentAction,
 					differentModelVersion, false, options.ConfigDir);
 			}
 
 			MainClass.Logger.Notice("LfMerge-{0} finished", MainClass.ModelVersion);
+			return result;
 		}
 
 		private static string RunAction(string projectCode, ActionNames currentAction)

--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -49,11 +49,15 @@ namespace LfMerge.QueueManager
 							projectCode, string.Format("{0}{1}", projectCode,
 								FdoFileHelper.ksFwDataXmlFileExtension));
 						var modelVersion = FwProject.GetModelVersion(projectPath);
-						MainClass.StartLfMerge(projectCode, queue.CurrentActionName,
+						queue.DequeueProject(projectCode);
+						int retCode = MainClass.StartLfMerge(projectCode, queue.CurrentActionName,
 							modelVersion, true);
 
-						// TODO: Verify actions complete before dequeuing
-						queue.DequeueProject(projectCode);
+						// TODO: If LfMerge fails, should we re-queue the project, or not?
+						if (retCode != 0)
+						{
+							// queue.EnqueueProject(projectCode);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This should ensure that LF doesn't get "stuck" thinking the project is pending. Now, what can happen is that LF's pending message disappears a second or so before the project starts the S/R process, but that's not a bad experience from the user's point of view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/39)
<!-- Reviewable:end -->
