### PR TITLE
Send/Receive Chorus Notes with LF comments

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -76,7 +76,7 @@ namespace LfMerge.Core.Tests.Actions
 			if (_recordFactory == null)
 				throw new AssertionException("Sync tests need a mock MongoProjectRecordFactory in order to work.");
 
-			_transferFdoToMongo = new TransferFdoToMongoAction(_env.Settings, _env.Logger, _mongoConnection);
+			_transferFdoToMongo = new TransferFdoToMongoAction(_env.Settings, _env.Logger, _mongoConnection, _recordFactory);
 		}
 
 		[TearDown]

--- a/src/LfMerge.Core.Tests/Fdo/FdoTestBase.cs
+++ b/src/LfMerge.Core.Tests/Fdo/FdoTestBase.cs
@@ -128,7 +128,8 @@ namespace LfMerge.Core.Tests.Fdo
 			sutFdoToMongo = new TransferFdoToMongoAction(
 				_env.Settings,
 				_env.Logger,
-				_conn
+				_conn,
+				_recordFactory
 			);
 
 			var convertCustomField = new ConvertFdoToMongoCustomField(_cache, _servLoc, _env.Logger);

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -305,6 +305,36 @@ namespace LfMerge.Core.Tests
 				return result;
 			return null;
 		}
+
+		public IEnumerable<LfComment> GetComments(ILfProject project)
+		{
+			yield break;
+		}
+
+		public Dictionary<MongoDB.Bson.ObjectId, Guid> GetGuidsByObjectIdForCollection(ILfProject project, string collectionName)
+		{
+			return new Dictionary<MongoDB.Bson.ObjectId, Guid>();
+		}
+
+		public void UpdateComments(ILfProject project, List<LfComment> comments)
+		{
+			;
+		}
+
+		public void UpdateReplies(ILfProject project, List<Tuple<string, List<LfCommentReply>>> repliesFromFWWithCommentGuids)
+		{
+			;
+		}
+
+		public void SetCommentReplyGuids(ILfProject project, IDictionary<string,Guid> uniqIdToGuidMappings)
+		{
+			// No-op. TODO: Implement something that stores a simple comment-replies data structure so we can unit test.
+		}
+
+		public void SetCommentGuids(ILfProject project, IDictionary<string,Guid> commentIdToGuidMappings)
+		{
+			// No-op. TODO: Implement something that stores a simple comments dictionary so we can unit test.
+		}
 	}
 
 	public class MongoProjectRecordFactoryDouble: MongoProjectRecordFactory

--- a/src/LfMerge.Core/Actions/TransferFdoToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferFdoToMongoAction.cs
@@ -20,12 +20,14 @@ namespace LfMerge.Core.Actions
 		private FdoCache _cache;
 		private IFdoServiceLocator _servLoc;
 		private IMongoConnection _connection;
+		private MongoProjectRecordFactory _projectRecordFactory;
 
 		private ConvertFdoToMongoLexicon _lexiconConverter;
 
-		public TransferFdoToMongoAction(LfMergeSettings settings, ILogger logger, IMongoConnection conn) : base(settings, logger)
+		public TransferFdoToMongoAction(LfMergeSettings settings, ILogger logger, IMongoConnection conn, MongoProjectRecordFactory projectRecordFactory) : base(settings, logger)
 		{
 			_connection = conn;
+			_projectRecordFactory = projectRecordFactory;
 		}
 
 		protected override void DoRun(ILfProject project)
@@ -50,7 +52,7 @@ namespace LfMerge.Core.Actions
 				return;
 			}
 
-			_lexiconConverter = new ConvertFdoToMongoLexicon(project, Logger, _connection);
+			_lexiconConverter = new ConvertFdoToMongoLexicon(project, Logger, _connection, Progress, _projectRecordFactory);
 			_lexiconConverter.RunConversion();
 
 			_connection.SetLastSyncedDate(project, DateTime.UtcNow);

--- a/src/LfMerge.Core/Actions/TransferMongoToFdoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferMongoToFdoAction.cs
@@ -6,6 +6,7 @@ using LfMerge.Core.LanguageForge.Config;
 using LfMerge.Core.MongoConnector;
 using LfMerge.Core.Reporting;
 using LfMerge.Core.Settings;
+using Palaso.Progress;
 using SIL.FieldWorks.FDO;
 
 namespace LfMerge.Core.Actions
@@ -70,7 +71,7 @@ namespace LfMerge.Core.Actions
 				return;
 			}
 
-			var converter = new ConvertMongoToFdoLexicon(Settings, project, Logger, _connection, _projectRecord, EntryCounts);
+			var converter = new ConvertMongoToFdoLexicon(Settings, project, Logger, Progress, _connection, _projectRecord, EntryCounts);
 			converter.RunConversion();
 		}
 

--- a/src/LfMerge.Core/DataConverters/ConvertFdoToMongoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertFdoToMongoComments.cs
@@ -1,0 +1,291 @@
+// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LfMerge.Core.FieldWorks;
+using LfMerge.Core.Logging;
+using LfMerge.Core.MongoConnector;
+using LfMerge.Core.LanguageForge.Config;
+using LfMerge.Core.LanguageForge.Model;
+using Newtonsoft.Json;
+using Palaso.Progress;
+using SIL.FieldWorks.FDO;
+
+namespace LfMerge.Core.DataConverters
+{
+	public class ConvertFdoToMongoComments
+	{
+		private IMongoConnection _conn;
+		private ILfProject _project;
+		private ILogger _logger;
+		private IProgress _progress;
+		private FwServiceLocatorCache _servLoc;
+		private MongoProjectRecordFactory _factory;
+		public ConvertFdoToMongoComments(IMongoConnection conn, ILfProject proj, ILogger logger, IProgress progress, MongoProjectRecordFactory factory)
+		{
+			_conn = conn;
+			_project = proj;
+			_servLoc = proj.FieldWorksProject.ServiceLocator;
+			_logger = logger;
+			_progress = progress;
+			_factory = factory;
+		}
+
+		public void RunConversion()
+		{
+			LfProjectConfig config = _factory.Create(_project).Config;
+			FieldLists fieldConfigs = FieldListsForEntryAndSensesAndExamples(config);
+
+			var fixedComments = new List<LfComment>(_conn.GetComments(_project));
+			string allCommentsJson = JsonConvert.SerializeObject(fixedComments);
+			_logger.Debug("Doing Fdo->Mongo direction. The json for ALL comments from Mongo would be: {0}", allCommentsJson);
+			_logger.Debug("Doing Fdo->Mongo direction. About to call LfMergeBridge with that JSON...");
+			string bridgeOutput;
+			if (CallLfMergeBridge(allCommentsJson, out bridgeOutput))
+			{
+				string newCommentsStr = ConvertMongoToFdoComments.GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New comments not yet in LF: ");
+				string newRepliesStr = ConvertMongoToFdoComments.GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New replies on comments already in LF: ");
+				List<LfComment> comments = JsonConvert.DeserializeObject<List<LfComment>>(newCommentsStr);
+				List<Tuple<string, List<LfCommentReply>>> replies = JsonConvert.DeserializeObject<List<Tuple<string, List<LfCommentReply>>>>(newRepliesStr);
+
+				foreach (LfComment comment in comments)
+				{
+					// LfMergeBridge only sets the Guid in comment.Regarding, and leaves it to the LfMerge side to set the rest of the fields meaningfully
+					if (comment.Regarding != null)
+					{
+						Guid guid;
+						if (Guid.TryParse(comment.Regarding.TargetGuid ?? "", out guid))
+						{
+							// The GUID in Chorus notes MIGHT be an entry, or it might be a sense or an example sentence.
+							// We want to handle these three cases differently -- see FromTargetGuid below.
+							comment.Regarding = FromTargetGuid(guid, fieldConfigs);
+						}
+					}
+					_logger.Debug("Comment by {6} regarding field {0} (containing {1}) of word {2} (GUID {7}, meaning {3}) has content {4}{5} and status {8}",
+						comment.Regarding.FieldNameForDisplay,
+						comment.Regarding.FieldValue,
+						comment.Regarding.Word,
+						comment.Regarding.Meaning,
+						comment.Content,
+						comment.Replies.Count <= 0 ? "" : " and replies [" + String.Join(", ", comment.Replies.Select(reply => "\"" + reply.Content + "\"")) + "]",
+						comment.AuthorNameAlternate ?? "<null>",
+						comment.Regarding.TargetGuid,
+						comment.Status
+						);
+				}
+				_conn.UpdateComments(_project, comments);
+				_conn.UpdateReplies(_project, replies);
+			}
+			else
+			{
+				// Failure, which has already been logged so we don't need to log it again
+			}
+		}
+
+		public struct FieldLists
+		{
+			public LfConfigFieldList entryConfig;
+			public LfConfigFieldList senseConfig;
+			public LfConfigFieldList exampleConfig;
+		}
+
+		public FieldLists FieldListsForEntryAndSensesAndExamples(LfProjectConfig config)
+		{
+			FieldLists result = new FieldLists();
+			result.entryConfig = config.Entry;
+			result.senseConfig = null;
+			result.exampleConfig = null;
+			if (result.entryConfig != null && result.entryConfig.Fields.ContainsKey("senses"))
+				result.senseConfig = result.entryConfig.Fields["senses"] as LfConfigFieldList;
+			if (result.senseConfig != null && result.senseConfig.Fields.ContainsKey("examples"))
+				result.exampleConfig = result.senseConfig.Fields["examples"] as LfConfigFieldList;
+			return result;
+		}
+
+		public string Definition(ILexSense sense)
+		{
+			if (sense == null
+			 || sense.Definition == null
+			 || sense.Definition.BestAnalysisVernacularAlternative == null)
+			{
+				return "";
+			}
+			return sense.Definition.BestAnalysisVernacularAlternative.Text ?? "";
+		}
+
+		public string ExampleValue(ILexExampleSentence example)
+		{
+			if (example == null
+			 || example.Example == null
+			 || example.Example.BestAnalysisVernacularAlternative == null)
+			{
+				return "";
+			}
+			return example.Example.BestAnalysisVernacularAlternative.Text ?? "";
+		}
+
+		public string TitleCase(string input)
+		{
+			if (string.IsNullOrEmpty(input)) return "";
+			return Char.ToUpper(input[0]).ToString() + input.Substring(1);
+		}
+
+		public string FieldNameForDisplay(string field, LfConfigFieldList fieldList)
+		{
+			LfConfigFieldBase fieldConfig;
+			if (fieldList != null && fieldList.Fields.TryGetValue(field, out fieldConfig))
+			{
+				return fieldConfig.Label;
+			}
+			else
+			{
+				return TitleCase(field); // Fallback
+			}
+		}
+
+		public LfCommentRegarding FromTargetGuid(Guid guidOfUnknownFdoObject, FieldLists fieldConfigs)
+		{
+			var result = new LfCommentRegarding(); // Worst case, we'll return this empty object rather than null
+			ICmObject fdoObject = _servLoc.ObjectRepository.GetObject(guidOfUnknownFdoObject);
+			if (fdoObject == null) return result;
+			result.TargetGuid = fdoObject.Guid.ToString();
+			switch (fdoObject.ClassID)
+			{
+				case LexEntryTags.kClassId:
+				{
+					var entry = fdoObject as ILexEntry;
+					if (entry != null) // Paranoia; should never happen, but check anyway
+					{
+						result.Word = entry.ShortName;
+						result.Meaning = entry.NumberOfSensesForEntry < 1 ? "" : Definition(entry.SensesOS[0]);
+					}
+					break;
+				}
+				case LexSenseTags.kClassId:
+				{
+					var sense = fdoObject as ILexSense;
+					if (sense == null || sense.Entry == null) // Paranoia; should never happen, but check anyway
+						return result;
+					ILexEntry entry = sense.Entry;
+					result.TargetGuid = entry.Guid.ToString();
+					result.Word = entry.ShortName;
+					result.Meaning = Definition(sense);
+					result.Field = MagicStrings.LfFieldNameForDefinition; // Even if it's really the gloss, we'll say it's the definition for LF display purposes
+					result.FieldNameForDisplay = FieldNameForDisplay(result.Field, fieldConfigs.senseConfig);
+					result.FieldValue = result.Meaning;
+					break;
+				}
+				case LexExampleSentenceTags.kClassId:
+				{
+					var example = fdoObject as ILexExampleSentence;
+					if (example == null || example.Owner == null) // Paranoia; should never happen, but check anyway
+						return result;
+					var sense = example.Owner as ILexSense; // Example sentences are always owned by senses
+					if (sense == null || sense.Entry == null) // Paranoia; should never happen, but check anyway
+						return result;
+					ILexEntry entry = sense.Entry;
+					result.TargetGuid = entry.Guid.ToString();
+					result.Word = entry.ShortName;
+					result.Meaning = Definition(sense);
+					result.Field = MagicStrings.LfFieldNameForExampleSentence; // Even if it's really a subfield of the example, we'll say it's the example for LF display purposes
+					result.FieldNameForDisplay = FieldNameForDisplay(result.Field, fieldConfigs.exampleConfig);
+					result.FieldValue = ExampleValue(example);
+					break;
+				}
+				default:
+				{
+					// Last-ditch effort: climb the owner chain and maybe we'll hit a LexEntry
+					while (fdoObject.Owner != null && fdoObject.ClassID != LexEntryTags.kClassId)
+						fdoObject = fdoObject.Owner;
+					if (fdoObject != null && fdoObject.ClassID == LexEntryTags.kClassId)
+					{
+						var entry = fdoObject as ILexEntry;
+						if (entry != null)
+						{
+							result.Word = entry.ShortName;
+							result.Meaning = entry.NumberOfSensesForEntry < 1 ? "" : Definition(entry.SensesOS[0]);
+						}
+					}
+					// But if we didn't, then just give up
+					break;
+				}
+			}
+			return result;
+		}
+
+		public ILexEntry OwningEntry(Guid guidOfUnknownFdoObject)
+		{
+			Guid result = Guid.Empty;
+			var fdoObject = _servLoc.ObjectRepository.GetObject(guidOfUnknownFdoObject);
+			if (fdoObject == null)
+				return null;
+			switch (fdoObject.ClassID)
+			{
+				case LexEntryTags.kClassId:
+				{
+					return fdoObject as ILexEntry;
+				}
+				case LexSenseTags.kClassId:
+				{
+					var sense = fdoObject as ILexSense;
+					if (sense == null || sense.Entry == null)
+						return null;
+					return sense.Entry;
+				}
+				case LexExampleSentenceTags.kClassId:
+				{
+					var example = fdoObject as ILexExampleSentence;
+					if (example == null || example.Owner == null)
+						return null;
+					var sense = example.Owner as ILexSense;
+					if (sense == null || sense.Entry == null)
+						return null;
+					return sense.Entry;
+				}
+				case CmPictureTags.kClassId:
+				{
+					var picture = fdoObject as ICmPicture;
+					return picture.Owner as ILexEntry;
+				}
+				default:
+				{
+					// Last-ditch effort: climb the owner chain and maybe we'll hit a LexEntry
+					while (fdoObject.Owner != null && fdoObject.ClassID != LexEntryTags.kClassId)
+						fdoObject = fdoObject.Owner;
+					if (fdoObject != null && fdoObject.ClassID == LexEntryTags.kClassId)
+					{
+						return fdoObject as ILexEntry;
+					}
+					// But if we didn't, then just give up
+					return null;
+				}
+			}
+		}
+
+		public bool CallLfMergeBridge(string bridgeInput, out string bridgeOutput)
+		{
+			// Call into LF Bridge to do the work.
+			bridgeOutput = string.Empty;
+			using (var tmpFile = new Palaso.IO.TempFile(bridgeInput))
+			{
+				var options = new Dictionary<string, string>
+				{
+					{"-p", _project.FwDataPath},
+					{"serializedCommentsFromLfMerge", tmpFile.Path},
+				};
+				if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Get_Chorus_Notes", _progress,
+					options, out bridgeOutput))
+				{
+					_logger.Error("Got an error from Language_Forge_Get_Chorus_Notes: {0}", bridgeOutput);
+					return false;
+				}
+				else
+				{
+					_logger.Debug("Got the JSON from Language_Forge_Get_Chorus_Notes: {0}", bridgeOutput);
+					return true;
+				}
+			}
+		}
+	}
+}

--- a/src/LfMerge.Core/DataConverters/ConvertFdoToMongoLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertFdoToMongoLexicon.cs
@@ -10,6 +10,7 @@ using LfMerge.Core.LanguageForge.Model;
 using LfMerge.Core.Logging;
 using LfMerge.Core.MongoConnector;
 using MongoDB.Bson;
+using Palaso.Progress;
 using SIL.CoreImpl;
 using SIL.FieldWorks.Common.COMInterfaces;
 using SIL.FieldWorks.FDO;
@@ -21,9 +22,12 @@ namespace LfMerge.Core.DataConverters
 		private ILfProject LfProject { get; set; }
 		private FwProject FwProject { get; set; }
 		private FdoCache Cache { get; set; }
+		private IProgress Progress { get; set; }
 		private FwServiceLocatorCache ServiceLocator { get; set; }
 		private ILogger Logger { get; set; }
 		private IMongoConnection Connection { get; set; }
+		private MongoProjectRecordFactory ProjectRecordFactory { get; set; }
+
 
 		private int _wsEn;
 
@@ -45,11 +49,13 @@ namespace LfMerge.Core.DataConverters
 
 		//private ConvertFdoToMongoOptionList _convertAnthroCodesOptionList;
 
-		public ConvertFdoToMongoLexicon(ILfProject lfProject, ILogger logger, IMongoConnection connection)
+		public ConvertFdoToMongoLexicon(ILfProject lfProject, ILogger logger, IMongoConnection connection, IProgress progress, MongoProjectRecordFactory projectRecordFactory)
 		{
 			LfProject = lfProject;
 			Logger = logger;
 			Connection = connection;
+			Progress = progress;
+			ProjectRecordFactory = projectRecordFactory;
 
 			FwProject = LfProject.FieldWorksProject;
 			Cache = FwProject.Cache;
@@ -133,6 +139,9 @@ namespace LfMerge.Core.DataConverters
 			LfProject.IsInitialClone = false;
 
 			RemoveMongoEntriesDeletedInFdo();
+			Logger.Debug("Running FtMComments, should see comments show up below:");
+			var commCvtr = new ConvertFdoToMongoComments(Connection, LfProject, Logger, Progress, ProjectRecordFactory);
+			commCvtr.RunConversion();
 		}
 
 		private void RemoveMongoEntriesDeletedInFdo()

--- a/src/LfMerge.Core/DataConverters/ConvertMongoToFdoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertMongoToFdoComments.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using LfMerge.Core.Actions.Infrastructure;
+using LfMerge.Core.Logging;
+using LfMerge.Core.MongoConnector;
+using LfMerge.Core.LanguageForge.Model;
+using Newtonsoft.Json;
+using Palaso.Progress;
+
+namespace LfMerge.Core.DataConverters
+{
+	public class ConvertMongoToFdoComments
+	{
+		private IMongoConnection _conn;
+		private ILfProject _project;
+		private ILogger _logger;
+		private IProgress _progress;
+		public ConvertMongoToFdoComments(IMongoConnection conn, ILfProject proj, ILogger logger, IProgress progress)
+		{
+			_conn = conn;
+			_project = proj;
+			_logger = logger;
+			_progress = progress;
+		}
+		public void RunConversion(Dictionary<MongoDB.Bson.ObjectId, Guid> entryObjectIdToGuidMappings)
+		{
+			var commentsWithIds = new List<KeyValuePair<string, LfComment>>();
+			foreach (LfComment comment in _conn.GetComments(_project))
+			{
+				Guid guid;
+				// LfMergeBridge wants lex entry GUIDs (passed along in comment.Regarding.TargetGuid), not Mongo ObjectIds like comment.EntryRef contains.
+				if (comment.EntryRef != null && entryObjectIdToGuidMappings.TryGetValue(comment.EntryRef, out guid))
+				{
+					comment.Regarding.TargetGuid = guid.ToString();
+				}
+				commentsWithIds.Add(new KeyValuePair<string, LfComment>(comment.Id.ToString(), comment));
+			}
+			string allCommentsJson = JsonConvert.SerializeObject(commentsWithIds);
+			string bridgeOutput;
+			CallLfMergeBridge(allCommentsJson, out bridgeOutput);
+			// LfMergeBridge returns two lists of IDs (comment IDs or reply IDs) that need to have their GUIDs updated in Mongo.
+			string commentGuidMappingsStr = GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New comment ID->Guid mappings: ");
+			string replyGuidMappingsStr = GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New reply ID->Guid mappings: ");
+			Dictionary<string, Guid> commentIdToGuidMappings = ParseGuidMappings(commentGuidMappingsStr);
+			Dictionary<string, Guid> uniqIdToGuidMappings = ParseGuidMappings(replyGuidMappingsStr);
+			_conn.SetCommentGuids(_project, commentIdToGuidMappings);
+			_conn.SetCommentReplyGuids(_project, uniqIdToGuidMappings);
+		}
+
+		public bool CallLfMergeBridge(string bridgeInput, out string bridgeOutput)
+		{
+			bridgeOutput = string.Empty;
+			using (var tmpFile = new Palaso.IO.TempFile(bridgeInput))
+			{
+				var options = new Dictionary<string, string>
+				{
+					{"-p", _project.FwDataPath},
+					{"serializedCommentsFromLfMerge", tmpFile.Path}
+				};
+				try {
+				if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Write_To_Chorus_Notes", _progress,
+					options, out bridgeOutput))
+				{
+					_logger.Error("Got an error from Language_Forge_Write_To_Chorus_Notes: {0}", bridgeOutput);
+					return false;
+				}
+				else
+				{
+					_logger.Debug("Good  output from Language_Forge_Write_To_Chorus_Notes: {0}", bridgeOutput);
+					return true;
+				}
+				}
+				catch (NullReferenceException)
+				{
+					_logger.Debug("Got an exception. Before rethrowing it, here is what LfMergeBridge sent:");
+					_logger.Debug("{0}", bridgeOutput);
+					throw;
+				}
+			}
+		}
+
+		public static string GetPrefixedStringFromLfMergeBridgeOutput(string lfMergeBridgeOutput, string prefix)
+		{
+			if (string.IsNullOrEmpty(prefix) || string.IsNullOrEmpty(lfMergeBridgeOutput))
+			{
+				return string.Empty;
+			}
+			string result = LfMergeBridgeServices.GetLineContaining(lfMergeBridgeOutput, prefix);
+			if (result.StartsWith(prefix))
+			{
+				return result.Substring(prefix.Length);
+			}
+			else
+			{
+				return string.Empty; // If the "prefix" wasn't actually a prefix, this wasn't the string we wanted.
+			}
+		}
+
+		public Dictionary<string, Guid> ParseGuidMappings(string input)
+		{
+			string[] parts = input.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+			var result = new Dictionary<string, Guid>();
+			foreach (string part in parts)
+			{
+				string[] kv = part.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+				if (kv.Length == 2)
+				{
+					Guid parsed;
+					if (Guid.TryParse(kv[1], out parsed))
+					{
+						result[kv[0]] = parsed;
+					}
+				}
+			}
+			return result;
+		}
+	}
+}

--- a/src/LfMerge.Core/LanguageForge/Model/LfComment.cs
+++ b/src/LfMerge.Core/LanguageForge/Model/LfComment.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace LfMerge.Core.LanguageForge.Model
+{
+	public class LfComment : LfFieldBase, IHasNullableGuid
+	{
+		public ObjectId Id { get; set; }
+		[BsonRepresentation(BsonType.String)]
+		public Guid? Guid { get; set; }
+		public LfAuthorInfo AuthorInfo { get; set; }
+		public string AuthorNameAlternate { get; set; } // Used in sending comments to FW; should be null when serializing to Mongo
+		public LfCommentRegarding Regarding { get; set; }
+		public DateTime DateCreated { get; set; }
+		public DateTime DateModified { get; set; }
+		public string Content { get; set; }
+		public string Status { get; set; }
+		public bool IsDeleted { get; set; }
+		public List<LfCommentReply> Replies { get; set; }
+		public ObjectId EntryRef { get; set; }
+		public int Score { get; set; }
+
+		public bool ShouldSerializeGuid() { return (Guid != null && Guid.Value != System.Guid.Empty); }
+		public bool ShouldSerializeDateCreated() { return true; }
+		public bool ShouldSerializeDateModified() { return true; }
+		public bool ShouldSerializeContent() { return ( ! String.IsNullOrEmpty(Content)); }
+		public bool ShouldSerializeAuthorNameAlternate() { return ( ! String.IsNullOrEmpty(AuthorNameAlternate)); }
+		public bool ShouldSerializeReplies() { return (Replies != null && Replies.Count > 0); }
+
+		public LfComment() {
+			Replies = new List<LfCommentReply>();
+		}
+	}
+}
+

--- a/src/LfMerge.Core/LanguageForge/Model/LfCommentRegarding.cs
+++ b/src/LfMerge.Core/LanguageForge/Model/LfCommentRegarding.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace LfMerge.Core.LanguageForge.Model
+{
+	public class LfCommentRegarding : LfFieldBase
+	{
+		public string TargetGuid { get; set; }
+		public string Field { get; set; }
+		public string FieldNameForDisplay { get; set; }
+		public string FieldValue { get; set; }
+		public string InputSystem { get; set; }
+		public string InputSystemAbbreviation { get; set; }
+		public string Word { get; set; }
+		public string Meaning { get; set; }
+
+		public bool ShouldSerializeEntryGuid() { return ( ! String.IsNullOrEmpty(TargetGuid)); }
+		public bool ShouldSerializeField() { return ( ! String.IsNullOrEmpty(Field)); }
+		public bool ShouldSerializeFieldNameForDisplay() { return ( ! String.IsNullOrEmpty(FieldNameForDisplay)); }
+		public bool ShouldSerializeFieldValue() { return ( ! String.IsNullOrEmpty(FieldValue)); }
+		public bool ShouldSerializeInputSystem() { return ( ! String.IsNullOrEmpty(InputSystem)); }
+		public bool ShouldSerializeInputSystemAbbreviation() { return ( ! String.IsNullOrEmpty(InputSystemAbbreviation)); }
+		public bool ShouldSerializeWord() { return ( ! String.IsNullOrEmpty(Word)); }
+		public bool ShouldSerializeMeaning() { return ( ! String.IsNullOrEmpty(Meaning)); }
+	}
+}
+

--- a/src/LfMerge.Core/LanguageForge/Model/LfCommentReply.cs
+++ b/src/LfMerge.Core/LanguageForge/Model/LfCommentReply.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace LfMerge.Core.LanguageForge.Model
+{
+	[BsonIgnoreExtraElements] // WARNING: Beware of using FindOneAndReplace() with IgnoreExtraElements, as you can lose data
+	public class LfCommentReply : LfFieldBase, IHasNullableGuid
+	{
+		[BsonRepresentation(BsonType.String)]
+		public Guid? Guid { get; set; }
+		public LfAuthorInfo AuthorInfo { get; set; }
+		public string AuthorNameAlternate { get; set; } // Used in sending comments to FW; should be null when serializing to Mongo
+		public string Content { get; set; }
+		[BsonElement("id")]
+		public string UniqId { get; set; }  // If we name this field "Id", the C# driver tries to map it to _id and always thinks it is null
+		public bool IsDeleted { get; set; }
+
+		public bool ShouldSerializeGuid() { return (Guid != null && Guid.Value != System.Guid.Empty); }
+		public bool ShouldSerializeContent() { return ( ! String.IsNullOrEmpty(Content)); }
+		public bool ShouldSerializeAuthorNameAlternate() { return ( ! String.IsNullOrEmpty(AuthorNameAlternate)); }
+		public bool ShouldSerializeId() { return ( ! String.IsNullOrEmpty(UniqId)); }
+		// We almost always want to store the IsDeleted value, unless the reply is pretty much empty of any useful content.
+		public bool ShouldSerializeIsDeleted() { return IsDeleted || ShouldSerializeGuid() || ShouldSerializeContent() || ShouldSerializeId(); }
+
+		public LfCommentReply() {
+			// Any lists, etc., should be populated in here
+		}
+	}
+}
+

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -141,11 +141,13 @@
     <Compile Include="Actions\TransferMongoToFdoAction.cs" />
     <Compile Include="Actions\Infrastructure\ChorusHelper.cs" />
     <Compile Include="Actions\Infrastructure\LfMergeBridgeServices.cs" />
+    <Compile Include="DataConverters\ConvertFdoToMongoComments.cs" />
     <Compile Include="DataConverters\ConvertFdoToMongoCustomField.cs" />
     <Compile Include="DataConverters\ConvertFdoToMongoLexicon.cs" />
     <Compile Include="DataConverters\ConvertFdoToMongoOptionList.cs" />
     <Compile Include="DataConverters\ConvertFdoToMongoPartsOfSpeech.cs" />
     <Compile Include="DataConverters\ConvertFdoToMongoTsStrings.cs" />
+    <Compile Include="DataConverters\ConvertMongoToFdoComments.cs" />
     <Compile Include="DataConverters\ConvertMongoToFdoCustomField.cs" />
     <Compile Include="DataConverters\ConvertMongoToFdoLexicon.cs" />
     <Compile Include="DataConverters\ConvertMongoToFdoOptionList.cs" />
@@ -183,6 +185,9 @@
     <Compile Include="LanguageForge\Model\CustomMongoSerializerForBoolean.cs" />
     <Compile Include="LanguageForge\Model\IHasNullableGuid.cs" />
     <Compile Include="LanguageForge\Model\LfAuthorInfo.cs" />
+    <Compile Include="LanguageForge\Model\LfComment.cs" />
+    <Compile Include="LanguageForge\Model\LfCommentRegarding.cs" />
+    <Compile Include="LanguageForge\Model\LfCommentReply.cs" />
     <Compile Include="LanguageForge\Model\LfExample.cs" />
     <Compile Include="LanguageForge\Model\LfFieldBase.cs" />
     <Compile Include="LanguageForge\Model\LfInputSystemRecord.cs" />
@@ -209,6 +214,7 @@
     <Compile Include="MongoConnector\MongoProjectRecord.cs" />
     <Compile Include="MongoConnector\MongoProjectRecordFactory.cs" />
     <Compile Include="MongoConnector\MongoRegistrar.cs" />
+    <Compile Include="MongoConnector\PseudoPhp.cs" />
     <Compile Include="Queues\IQueue.cs" />
     <Compile Include="Queues\Queue.cs" />
     <Compile Include="Queues\QueueNames.cs" />

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -70,13 +70,20 @@ namespace LfMerge.Core
 
 		// Collections found in individual project DBs
 		public const string LfCollectionNameForLexicon = "lexicon";
+		public const string LfCollectionNameForLexiconComments = "lexiconComments";
 		public const string LfCollectionNameForOptionLists = "optionlists";
 
 		// Collections found in main DB
 		public const string LfCollectionNameForProjectRecords = "projects";
+
+		// Prefixes that LF wants for custom field names
 		public const string LfCustomFieldEntryPrefix = "customField_entry";
 		public const string LfCustomFieldSensesPrefix = "customField_senses";
 		public const string LfCustomFieldExamplePrefix = "customField_example";
+
+		// Field names to use in an LfCommentRegarding instance
+		public const string LfFieldNameForDefinition = "definition";
+		public const string LfFieldNameForExampleSentence = "definition";
 
 		// Fake language codes used in storing custom GenDate and int fields in Mongo
 		public const string LanguageCodeForGenDateFields = "qaa-Qaad";

--- a/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
@@ -21,11 +21,18 @@ namespace LfMerge.Core.MongoConnector
 		bool UpdateRecord(ILfProject project, LfOptionList data, string listCode);
 		bool RemoveRecord(ILfProject project, Guid guid);
 		Dictionary<string, LfInputSystemRecord>GetInputSystems(ILfProject project);
+		IEnumerable<LfComment> GetComments(ILfProject project);
+		void UpdateComments(ILfProject project, List<LfComment> comments);  // Should be void, but string for now as a very quick-and-dirty test
+		void UpdateReplies(ILfProject project, List<Tuple<string, List<LfCommentReply>>> repliesFromFWWithCommentGuids);
 		bool SetInputSystems(ILfProject project, Dictionary<string, LfInputSystemRecord> inputSystems,
 			List<string> vernacularWss, List<string> analysisWss, List<string> pronunciationWss);
 		bool SetCustomFieldConfig(ILfProject project, Dictionary<string, LfConfigFieldBase> lfCustomFieldList);
 		Dictionary<string, LfConfigFieldBase> GetCustomFieldConfig(ILfProject project);
 		bool SetLastSyncedDate(ILfProject project, DateTime? newSyncedDate);  // TODO: Decide if this is really where this method belongs
+		void SetCommentReplyGuids(ILfProject project, IDictionary<string,Guid> uniqIdToGuidMappings);
+		void SetCommentGuids(ILfProject project, IDictionary<string,Guid> commentIdToGuidMappings);
+		Dictionary <MongoDB.Bson.ObjectId, Guid> GetGuidsByObjectIdForCollection(ILfProject project, string collectionName);
+
 	}
 }
 

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -112,6 +112,15 @@ namespace LfMerge
 			}
 			catch (Exception e)
 			{
+				MainClass.Logger.Error("Got exception {0}", e.ToString());
+				if (projectCode == null)
+				{
+					MainClass.Logger.Error("Project code was null");
+				}
+				else
+				{
+					MainClass.Logger.Error("Project code was {0}", projectCode);
+				}
 				string errorMsg = string.Format("Putting project {0} on hold due to unhandled exception: \n{1}",
 					projectCode, e);
 				MainClass.Logger.Error(errorMsg);


### PR DESCRIPTION
The corresponding [LfMergeBridge PR](https://github.com/sillsdev/flexbridge/pull/149) should be merged in first, then built, before this PR is merged. That will allow the TeamCity build process to obtain an LfMergeBridge DLL that knows the new GetChorusNotes and WriteToChorusNotes actions. If this PR is merged too soon, the resulting LfMerge.exe will run, but will throw an exception when you try to do a Send/Receive and it tries to handle comments.

There are no unit tests yet, but I'm creating the PR now so that we can see how it builds on TeamCity, and so that the code can be reviewed while we wait for the LfMergeBridge PR to be merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/41)
<!-- Reviewable:end -->
