### PR TITLE
Convert LIFT IDs to NFC when storing them in Mongo

### DIFF
--- a/src/LfMerge.Core/DataConverters/ConvertFdoToMongoLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertFdoToMongoLexicon.cs
@@ -271,7 +271,14 @@ namespace LfMerge.Core.DataConverters
 				// fdoEtymology.LiftResidue not mapped
 			}
 			lfEntry.Guid = fdoEntry.Guid;
-			lfEntry.LiftId = fdoEntry.LIFTid;
+			if (fdoEntry.LIFTid == null)
+			{
+				lfEntry.LiftId = null;
+			}
+			else
+			{
+				lfEntry.LiftId = fdoEntry.LIFTid.Normalize(System.Text.NormalizationForm.FormC);  // Because LIFT files on disk are NFC and we need to make sure LiftIDs match those on disk
+			}
 			lfEntry.LiteralMeaning = ToMultiText(fdoEntry.LiteralMeaning);
 			if (fdoEntry.PrimaryMorphType != null) {
 				lfEntry.MorphologyType = fdoEntry.PrimaryMorphType.NameHierarchyString;
@@ -375,7 +382,14 @@ namespace LfMerge.Core.DataConverters
 
 			lfSense.GeneralNote = ToMultiText(fdoSense.GeneralNote);
 			lfSense.GrammarNote = ToMultiText(fdoSense.GrammarNote);
-			lfSense.LiftId = fdoSense.LIFTid;
+			if (fdoSense.LIFTid == null)
+			{
+				lfSense.LiftId = null;
+			}
+			else
+			{
+				lfSense.LiftId = fdoSense.LIFTid.Normalize(System.Text.NormalizationForm.FormC);  // Because LIFT files on disk are NFC and we need to make sure LiftIDs match those on disk
+			}
 			if (fdoSense.MorphoSyntaxAnalysisRA != null)
 			{
 				IPartOfSpeech secondaryPos = null; // Only used in derivational affixes


### PR DESCRIPTION
FDO objects are NFD internally, but we need to store LIFT IDs in a form that matches what they will be on disk. That will almost certainly be NFC, since most LIFT files that we deal with will have been exported from FDO. If we get any LIFT files from other sources, it's possible that there could be problems, but we'll deal with those later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/42)
<!-- Reviewable:end -->
