### PR TITLE
Only real changes should update DateModified

### DIFF
--- a/src/LfMerge.Core/DataConverters/ConvertFdoToMongoOptionList.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertFdoToMongoOptionList.cs
@@ -57,11 +57,9 @@ namespace LfMerge.Core.DataConverters
 				LfOptionListItem correspondingItem;
 				if (_lfOptionListItemByGuid.TryGetValue(poss.Guid, out correspondingItem))
 				{
-					bool thisItemWasModified = SetOptionListItemFromCmPossibility(correspondingItem, poss);
-					optionListDiffersFromOriginal |= thisItemWasModified;
-					// Two-step process because we don't want |= to short-circuit calling SetOptionListItemFromCmPossibility().
-					// QUESTION for code reviewers: would that intent have been clear if I had written the following line instead?
-					// optionListDiffersFromOriginal = SetOptionListItemFromCmPossibility(correspondingItem, poss) || optionListDiffersFromOriginal;
+					// One-way latch: once optionListDiffersFromOriginal becomes true, it should remain true.
+					// Do NOT reorder this || expression. We want the function call *first* so that it will never be short-circuited away.
+					optionListDiffersFromOriginal = SetOptionListItemFromCmPossibility(correspondingItem, poss) || optionListDiffersFromOriginal;
 				}
 				else
 				{


### PR DESCRIPTION
Specifically, if the fields in an LfOptionList haven't been modified at all, its DateModified shouldn't be updated either.

This has not been causing any bugs so far, but it does cause useless patches (where nothing has changed in Mongo except the DateModified value on option lists) to show up when using the lfmerge-autosrtests tool. With this change, that tool only creates patches if some actual data has changed in Mongo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/43)
<!-- Reviewable:end -->
