### PR TITLE
Allow to compile with Mono 5

### DIFF
--- a/src/FixFwData/FixFwData.csproj
+++ b/src/FixFwData/FixFwData.csproj
@@ -31,13 +31,14 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion)</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -48,7 +49,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\output\Release\</OutputPath>
-    <DefineConstants>TRACE;DBVERSION_$(DatabaseVersion)</DefineConstants>
+    <DefineConstants>TRACE;DBVERSION_$(DatabaseVersion);$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
@@ -60,7 +61,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000068</OutputPath>
-    <DefineConstants>DEBUG;TRACE;DBVERSION_7000068</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_7000068;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
@@ -73,7 +74,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000069</OutputPath>
-    <DefineConstants>DEBUG;TRACE;DBVERSION_7000069</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_7000069;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
@@ -86,7 +87,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000070</OutputPath>
-    <DefineConstants>DEBUG;TRACE;DBVERSION_7000070</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_7000070;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>

--- a/src/FixFwData/Program.cs
+++ b/src/FixFwData/Program.cs
@@ -12,7 +12,7 @@ using Palaso.Reporting;
 using SIL.FieldWorks.FixData;
 using SIL.Utils;
 
-#if __MonoCS__
+#if LINUX
 using Palaso.PlatformUtilities;
 using SIL.Linux.Logging;
 #endif
@@ -35,7 +35,7 @@ namespace FixFwData
 			return errorsOccurred ? 1 : 0;
 		}
 
-#if __MonoCS__
+#if LINUX
 		private static SyslogLogger logger = null;
 #endif
 		private static bool errorsOccurred = false;
@@ -43,7 +43,7 @@ namespace FixFwData
 
 		private static void logError(string description, bool errorFixed)
 		{
-#if __MonoCS__
+#if LINUX
 			if (logger == null)
 				Console.WriteLine(description);
 			else
@@ -65,13 +65,13 @@ namespace FixFwData
 		{
 			ErrorReport.EmailAddress = "flex_errors@sil.org";
 			ErrorReport.AddStandardProperties();
-#if __MonoCS__
+#if LINUX
 			if (Platform.IsUnix && Environment.GetEnvironmentVariable("DISPLAY") == null)
 				ExceptionHandler.Init(new SyslogExceptionHandler("FixFwData"));
 			else
 #endif
 				ExceptionHandler.Init();
-#if __MonoCS__
+#if LINUX
 			if (Platform.IsUnix)
 				logger = new SyslogLogger("FixFwData");
 #endif
@@ -97,7 +97,7 @@ namespace FixFwData
 				get { return null; }
 				set
 				{
-#if __MonoCS__
+#if LINUX
 					if (logger == null)
 						Console.Out.WriteLine(value);
 					else

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,13 +10,14 @@
     <RootNamespace>LfMerge.Core</RootNamespace>
     <AssemblyName>LfMerge.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_$(DatabaseVersion)</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_$(DatabaseVersion);$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -30,7 +32,7 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>FW8_COMPAT;DBVERSION_$(DatabaseVersion)</DefineConstants>
+    <DefineConstants>FW8_COMPAT;DBVERSION_$(DatabaseVersion);$(DefinePlatformConstants)</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug7000068|AnyCPU' ">
@@ -39,7 +41,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000068</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000068</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000068;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -51,7 +53,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000069</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000069</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000069;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -63,7 +65,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000070</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000070</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;DBVERSION_7000070;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/LfMerge.Core/Logging/SyslogLogger.cs
+++ b/src/LfMerge.Core/Logging/SyslogLogger.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2016 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
-#if __MonoCS__
+#if LINUX
 using SIL.Linux.Logging;
 #endif
 
@@ -9,18 +9,18 @@ namespace LfMerge.Core.Logging
 {
 	public class SyslogLogger : LoggerBase
 	{
-#if __MonoCS__
+#if LINUX
 		private SIL.Linux.Logging.SyslogLogger _logger;
 #endif
 
 		public SyslogLogger(string programName = null)
 		{
-#if __MonoCS__
+#if LINUX
 			_logger = new SIL.Linux.Logging.SyslogLogger(programName ?? "LfMerge");
 #endif
 		}
 
-#if __MonoCS__
+#if LINUX
 		private SyslogPriority SeverityToPriority(LogSeverity severity)
 		{
 			// If integer values of LogSeverity enum ever change, this function will need to be more complicated
@@ -31,14 +31,14 @@ namespace LfMerge.Core.Logging
 
 		public override void LogMany(LogSeverity severity, IEnumerable<string> messages)
 		{
-#if __MonoCS__
+#if LINUX
 			_logger.LogMany(SeverityToPriority(severity), messages);
 #endif
 		}
 
 		public override void Log(LogSeverity severity, string message)
 		{
-#if __MonoCS__
+#if LINUX
 			_logger.Log(SeverityToPriority(severity), message);
 #endif
 		}

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -9,13 +9,14 @@
     <RootNamespace>LfMerge</RootNamespace>
     <AssemblyName>LfMerge</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -25,12 +26,11 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\output\Release</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>FW8_COMPAT</DefineConstants>
+    <DefineConstants>TRACE;FW8_COMPAT;$(DefinePlatformConstants)</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug7000068|AnyCPU' ">
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000068</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -52,7 +52,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000069</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -64,7 +64,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\7000070</OutputPath>
-    <DefineConstants>DEBUG;TRACE;FW8_COMPAT</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;FW8_COMPAT;$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>


### PR DESCRIPTION
Mono 5 uses the Roslyn compiler which doesn't define __MonoCS__.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/46)
<!-- Reviewable:end -->
