### PR TITLE
 Implement cleanup of state files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ indent_style = tab
 tab_width = 4
 
 # Settings Visual Studio uses for the generated files
-[*.{csproj,resx,settings,vcxproj*,vdproj,xml}]
+[*.{csproj,resx,settings,vcxproj*,vdproj,xml,yml}]
 indent_style = space
 indent_size = 2
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,4 @@
 mode: Mainline
-next-version: 1.0
 branches:
   live:
     tag:
@@ -7,11 +6,26 @@ branches:
     is-mainline: true
   qa:
     mode: ContinuousDeployment
+    track-merge-target: true
     tag: beta
     regex: (origin/)?qa
   master:
     mode: ContinuousDeployment
+    track-merge-target: true
     tag: alpha
     regex: (origin/)?master
+  pull-request:
+    mode: ContinuousDeployment
+    track-merge-target: true
+    tag: PR
+    regex: (origin/)?PR
+    #The following two lines require a newer version of GitVersion
+    #tag-name-pattern: '[/-](?<number>\d+)[-/]'
+    #source-branches: [ 'master', 'qa', 'live' ]
+  local-dev:
+    mode: ContinuousDeployment
+    track-merge-target: true
+    tag: dev
+    regex: (origin/)?.*
 ignore:
   sha: []

--- a/LfMerge.TestApp/LfMerge.TestApp.csproj
+++ b/LfMerge.TestApp/LfMerge.TestApp.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>LfMerge.TestApp</RootNamespace>
     <AssemblyName>LfMerge.TestApp</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/FixFwData/FixFwData.csproj
+++ b/src/FixFwData/FixFwData.csproj
@@ -32,6 +32,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,7 +43,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -52,7 +52,6 @@
     <DefineConstants>TRACE;DBVERSION_$(DatabaseVersion);$(DefinePlatformConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug7000068|AnyCPU' ">
@@ -65,7 +64,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug7000069|AnyCPU' ">
@@ -78,7 +76,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug7000070|AnyCPU' ">
@@ -91,7 +88,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>

--- a/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
+++ b/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
@@ -69,6 +69,10 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Bugsnag, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Bugsnag.2.2.0\lib\net45\Bugsnag.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -109,6 +113,8 @@
     <Reference Include="LfMergeBridge">
       <HintPath>..\..\lib\LfMergeBridge.dll</HintPath>
     </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup Condition=" '$(DatabaseVersion)' == '7000070'">
     <Reference Include="FDO">
@@ -156,6 +162,7 @@
     <Compile Include="MercurialServer.cs" />
     <Compile Include="Fdo\DataConverters\ConvertMongoToFdoTsStringsTests.cs" />
     <Compile Include="Actions\Infrastructure\ChorusHelperTests.cs" />
+    <Compile Include="Tools\JanitorTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/LfMerge.Core.Tests/Queues/QueueTests.cs
+++ b/src/LfMerge.Core.Tests/Queues/QueueTests.cs
@@ -48,10 +48,10 @@ namespace LfMerge.Core.Tests.Queues
 		}
 
 		[Test]
-		[ExpectedException( "System.ArgumentException" )]
 		public void Ctor_CantCreateQueueForNone()
 		{
-			new Queue(_env.Settings, QueueNames.None);
+			Assert.That(() => new Queue(_env.Settings, QueueNames.None),
+				Throws.ArgumentException);
 		}
 
 		[Test]

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Bugsnag.Payload;
 using IniParser.Model;
 using LfMerge.Core.Actions;
 using LfMerge.Core.Actions.Infrastructure;
@@ -18,6 +19,7 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 using Moq;
+using Exception = System.Exception;
 
 namespace LfMerge.Core.Tests
 {
@@ -83,7 +85,7 @@ namespace LfMerge.Core.Tests
 			ConfigDir = Path.GetRandomFileName();
 		}
 
-		public LfMergeSettingsDouble(string replacementBaseDir) : base()
+		public LfMergeSettingsDouble(string replacementBaseDir)
 		{
 			var replacementConfig = new IniData(ParsedConfig);
 			replacementConfig.Global["BaseDir"] = replacementBaseDir;
@@ -488,6 +490,32 @@ namespace LfMerge.Core.Tests
 		{
 			cloneResult = _cloneResult;
 			return true;
+		}
+	}
+
+	class ExceptionLoggingDouble : ExceptionLogging
+	{
+		private List<Report> _exceptions = new List<Report>();
+
+		private ExceptionLoggingDouble() : base("unit-test", "foo", ".")
+		{
+		}
+
+		protected override void OnBeforeNotify(Report report)
+		{
+			_exceptions.Add(report);
+		}
+
+		public List<Report> Exceptions
+		{
+			get { return _exceptions; }
+		}
+
+		public static ExceptionLoggingDouble Initialize()
+		{
+			var exceptionLoggingDouble = new ExceptionLoggingDouble();
+			Client = exceptionLoggingDouble;
+			return exceptionLoggingDouble;
 		}
 	}
 }

--- a/src/LfMerge.Core.Tests/Tools/JanitorTests.cs
+++ b/src/LfMerge.Core.Tests/Tools/JanitorTests.cs
@@ -1,0 +1,113 @@
+// // Copyright (c) 2018 SIL International
+// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using LfMerge.Core.Logging;
+using LfMerge.Core.Queues;
+using LfMerge.Core.Tools;
+using NUnit.Framework;
+
+namespace LfMerge.Core.Tests.Tools
+{
+	[TestFixture]
+	public class JanitorTests
+	{
+		private TestEnvironment _env;
+		private ExceptionLoggingDouble _exceptionLoggingDouble;
+
+		[SetUp]
+		public void Setup()
+		{
+			_env = new TestEnvironment(registerProcessingStateDouble: false);
+			_exceptionLoggingDouble = ExceptionLoggingDouble.Initialize();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			_env.Dispose();
+		}
+
+		[TestCase(ProcessingState.SendReceiveStates.CLONED)]
+		[TestCase(ProcessingState.SendReceiveStates.ERROR)]
+		[TestCase(ProcessingState.SendReceiveStates.HOLD)]
+		[TestCase(ProcessingState.SendReceiveStates.IDLE)]
+		public void CleanupAndRescheduleJobs_NothingToDo(ProcessingState.SendReceiveStates srState)
+		{
+			// Setup
+			var state = new ProcessingState(TestContext.CurrentContext.Test.Name, _env.Settings) {
+				SRState = srState
+			};
+			state.Serialize();
+
+			// Execute
+			var janitor = new Janitor(_env.Settings, _env.Logger);
+			janitor.CleanupAndRescheduleJobs();
+
+			// Verify
+			var queue = Queue.GetQueue(QueueNames.Synchronize);
+			Assert.That(queue.IsEmpty, Is.True);
+
+			var newState = ProcessingState.Deserialize(TestContext.CurrentContext.Test.Name);
+			Assert.That(newState.SRState, Is.EqualTo(srState));
+
+			Assert.That(_exceptionLoggingDouble.Exceptions.Count, Is.EqualTo(0));
+		}
+
+		[TestCase(ProcessingState.SendReceiveStates.CLONING)]
+		[TestCase(ProcessingState.SendReceiveStates.SYNCING)]
+		public void CleanupAndRescheduleJobs_Reschedule(ProcessingState.SendReceiveStates srState)
+		{
+			// Setup
+			var testName = TestContext.CurrentContext.Test.Name;
+			var state = new ProcessingState(testName, _env.Settings) {
+				SRState = srState
+			};
+			state.Serialize();
+
+			// Execute
+			var janitor = new Janitor(_env.Settings, _env.Logger);
+			janitor.CleanupAndRescheduleJobs();
+
+			// Verify
+			var queue = Queue.GetQueue(QueueNames.Synchronize);
+			Assert.That(queue.QueuedProjects, Is.EqualTo(new[] { testName }));
+
+			var newState = ProcessingState.Deserialize(testName);
+			Assert.That(newState.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.IDLE));
+
+			Assert.That(_exceptionLoggingDouble.Exceptions.Count, Is.EqualTo(1));
+			var report = _exceptionLoggingDouble.Exceptions[0];
+			Assert.That(report.OriginalException, Is.TypeOf<ProjectInUncleanStateException>());
+			Assert.That(report.OriginalException.Message, Is.EqualTo(string.Format(
+				"QueueManager detected project 'CleanupAndRescheduleJobs_Reschedule({0})' in unclean state '{0}'; rescheduled",
+				srState)));
+		}
+
+		[TestCase(42)]
+		public void CleanupAndRescheduleJobs_UnknownState(ProcessingState.SendReceiveStates srState)
+		{
+			// Setup
+			var testName = TestContext.CurrentContext.Test.Name;
+			var state = new ProcessingState(testName, _env.Settings) {
+				SRState = srState
+			};
+			state.Serialize();
+
+			// Execute
+			var janitor = new Janitor(_env.Settings, _env.Logger);
+			janitor.CleanupAndRescheduleJobs();
+
+			// Verify
+			var queue = Queue.GetQueue(QueueNames.Synchronize);
+			Assert.That(queue.QueuedProjects, Is.EqualTo(new[] { testName }));
+
+			var newState = ProcessingState.Deserialize(testName);
+			Assert.That(newState.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.IDLE));
+
+			Assert.That(_exceptionLoggingDouble.Exceptions.Count, Is.EqualTo(1));
+			var report = _exceptionLoggingDouble.Exceptions[0];
+			Assert.That(report.OriginalException, Is.TypeOf<ProjectInUncleanStateException>());
+			Assert.That(report.OriginalException.Message, Is.EqualTo("QueueManager detected unknown state '42' for project 'CleanupAndRescheduleJobs_UnknownState(42)'; rescheduled"));
+		}
+	}
+}

--- a/src/LfMerge.Core.Tests/packages.config
+++ b/src/LfMerge.Core.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.Extras.Moq" version="4.0.0" targetFramework="net45" />
+  <package id="Bugsnag" version="2.2.0" targetFramework="net45" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="ini-parser" version="2.2.4" targetFramework="net45" />
   <package id="MongoDB.Bson" version="2.2.1" targetFramework="net45" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -233,6 +233,8 @@
     <Compile Include="Settings\LfMergeSettings.cs" />
     <Compile Include="MainClass.cs" />
     <Compile Include="FieldWorks\FwServiceLocatorCache.cs" />
+    <Compile Include="Tools\Janitor.cs" />
+    <Compile Include="Tools\ProjectInUncleanStateException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\GitVersionTask.4.0.0-beta0009\build\GitVersionTask.targets" Condition="Exists('..\..\packages\GitVersionTask.4.0.0-beta0009\build\GitVersionTask.targets')" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0"
-         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +10,7 @@
     <AssemblyName>LfMerge.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -72,16 +72,17 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bugsnag, Version=2.0.2.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
+    <Reference Include="Bugsnag, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Bugsnag.2.2.0\lib\net45\Bugsnag.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="icu.net, Version=2.3.3.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66">
+      <HintPath>..\..\packages\icu.net.2.3.3\lib\net40\icu.net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
-    </Reference>
-    <Reference Include="icu.net">
-      <HintPath>..\..\packages\icu.net.2.0.0\lib\net40\icu.net.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser">
       <HintPath>..\..\packages\ini-parser.2.2.4\lib\net20\INIFileParser.dll</HintPath>

--- a/src/LfMerge.Core/Logging/ExceptionLogging.cs
+++ b/src/LfMerge.Core/Logging/ExceptionLogging.cs
@@ -23,7 +23,7 @@ namespace LfMerge.Core.Logging
 	{
 		private readonly string _solutionPath;
 
-		private ExceptionLogging(string apiKey, string executable, string callerFilePath)
+		protected ExceptionLogging(string apiKey, string executable, string callerFilePath)
 			: base(apiKey)
 		{
 			_solutionPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(callerFilePath), "../.."));
@@ -246,7 +246,7 @@ namespace LfMerge.Core.Logging
 			return ret.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 		}
 
-		private void OnBeforeNotify(Report report)
+		protected virtual void OnBeforeNotify(Report report)
 		{
 			var exception = report.Event.Exceptions[0].OriginalException;
 			var stackTrace = new StackTrace(exception, true);
@@ -271,6 +271,6 @@ namespace LfMerge.Core.Logging
 			Client = new ExceptionLogging(apiKey, executable, filename);
 		}
 
-		public static ExceptionLogging Client { get; private set; }
+		public static ExceptionLogging Client { get; protected set; }
 	}
 }

--- a/src/LfMerge.Core/Tools/Janitor.cs
+++ b/src/LfMerge.Core/Tools/Janitor.cs
@@ -1,0 +1,61 @@
+// // Copyright (c) 2018 SIL International
+// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.IO;
+using LfMerge.Core.Logging;
+using LfMerge.Core.Queues;
+using LfMerge.Core.Settings;
+
+namespace LfMerge.Core.Tools
+{
+	public class Janitor
+	{
+		private LfMergeSettings Settings { get; set; }
+		private ILogger Logger { get; set; }
+
+		public Janitor(LfMergeSettings settings, ILogger logger)
+		{
+			Settings = settings;
+			Logger = logger;
+		}
+
+		public void CleanupAndRescheduleJobs()
+		{
+			foreach (var file in Directory.EnumerateFiles(Settings.StateDirectory))
+			{
+				var projectCode = Path.GetFileNameWithoutExtension(file);
+				var state = ProcessingState.Deserialize(projectCode);
+				switch (state.SRState)
+				{
+					case ProcessingState.SendReceiveStates.CLONED:
+					case ProcessingState.SendReceiveStates.IDLE:
+					case ProcessingState.SendReceiveStates.HOLD:
+					case ProcessingState.SendReceiveStates.ERROR:
+						// Nothing to do
+						break;
+					case ProcessingState.SendReceiveStates.CLONING:
+					case ProcessingState.SendReceiveStates.SYNCING:
+						RescheduleProject(projectCode, state,
+							string.Format("QueueManager detected project '{0}' in unclean state '{1}'; rescheduled",
+							projectCode, state.SRState));
+						break;
+					default:
+						RescheduleProject(projectCode, state,
+							string.Format("QueueManager detected unknown state '{0}' for project '{1}'; rescheduled",
+								state.SRState, projectCode));
+						break;
+				}
+			}
+		}
+
+		private void RescheduleProject(string projectCode, ProcessingState state, string message)
+		{
+			Logger.Error(message);
+			ExceptionLogging.Client.Notify(new ProjectInUncleanStateException(message));
+			state.SRState = ProcessingState.SendReceiveStates.IDLE;
+			state.Serialize();
+			Queue.GetQueue(QueueNames.Synchronize).EnqueueProject(projectCode);
+		}
+	}
+}

--- a/src/LfMerge.Core/Tools/ProjectInUncleanStateException.cs
+++ b/src/LfMerge.Core/Tools/ProjectInUncleanStateException.cs
@@ -1,0 +1,14 @@
+// // Copyright (c) 2018 SIL International
+// // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+
+namespace LfMerge.Core.Tools
+{
+	public class ProjectInUncleanStateException: Exception
+	{
+		public ProjectInUncleanStateException(string message) : base(message)
+		{
+		}
+	}
+}

--- a/src/LfMerge.Core/packages.config
+++ b/src/LfMerge.Core/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Bugsnag" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag" version="2.2.0" targetFramework="net45" />
   <package id="GitVersionTask" version="4.0.0-beta0009" targetFramework="net45" developmentDependency="true" />
-  <package id="icu.net" version="2.0.0" targetFramework="net45" />
+  <package id="icu.net" version="2.3.3" targetFramework="net45" />
   <package id="ini-parser" version="2.2.4" targetFramework="net45" />
   <package id="MongoDB.Bson" version="2.2.1" targetFramework="net45" />
   <package id="MongoDB.Driver" version="2.2.1" targetFramework="net45" />

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>LfMerge</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -71,8 +72,8 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bugsnag, Version=2.0.2.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
+    <Reference Include="Bugsnag, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Bugsnag.2.2.0\lib\net45\Bugsnag.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/LfMerge/packages.config
+++ b/src/LfMerge/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Bugsnag" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag" version="2.2.0" targetFramework="net45" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="GitVersionTask" version="4.0.0-beta0009" targetFramework="net45" developmentDependency="true" />
   <package id="ini-parser" version="2.2.4" targetFramework="net45" />

--- a/src/LfMergeAuxTool/LfMergeAuxTool.csproj
+++ b/src/LfMergeAuxTool/LfMergeAuxTool.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>LfMergeAuxTool</RootNamespace>
     <AssemblyName>LfMergeAuxTool</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,12 +74,13 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bugsnag, Version=2.0.2.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
+    <Reference Include="Bugsnag, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Bugsnag.2.2.0\lib\net45\Bugsnag.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="CommandLine">

--- a/src/LfMergeAuxTool/packages.config
+++ b/src/LfMergeAuxTool/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bugsnag" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag" version="2.2.0" targetFramework="net45" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
 </packages>

--- a/src/LfMergeQueueManager/LfMergeQueueManager.csproj
+++ b/src/LfMergeQueueManager/LfMergeQueueManager.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>LfMerge.QueueManager</RootNamespace>
     <AssemblyName>LfMergeQueueManager</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,12 +71,13 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bugsnag, Version=2.0.2.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\Bugsnag.2.0.2\lib\net45\Bugsnag.dll</HintPath>
+    <Reference Include="Bugsnag, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Bugsnag.2.2.0\lib\net45\Bugsnag.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="CommandLine">

--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -10,6 +10,7 @@ using LfMerge.Core.FieldWorks;
 using LfMerge.Core.Logging;
 using LfMerge.Core.Queues;
 using LfMerge.Core.Settings;
+using LfMerge.Core.Tools;
 using Palaso.IO.FileLock;
 using SIL.FieldWorks.FDO;
 
@@ -40,6 +41,9 @@ namespace LfMerge.QueueManager
 
 				if (!CheckSetup(settings))
 					return;
+
+				// Cleanup any hang projects
+				new Janitor(settings, MainClass.Logger).CleanupAndRescheduleJobs();
 
 				for (var queue = Queue.FirstQueueWithWork;
 					queue != null;

--- a/src/LfMergeQueueManager/packages.config
+++ b/src/LfMergeQueueManager/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Bugsnag" version="2.0.2" targetFramework="net45" />
+  <package id="Bugsnag" version="2.2.0" targetFramework="net45" />
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="GitVersionTask" version="4.0.0-beta0009" targetFramework="net45" developmentDependency="true" />
   <package id="ini-parser" version="2.2.4" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This change adds new functionality to the queue manager. Before it
processes the queued projects it checks the state files. Any state
file that is still in the CLONING or SYNCING state (although no
LfMerge process can run at this point) will be reset to IDLE and
re-scheduled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/61)
<!-- Reviewable:end -->
