### PR TITLE
Set headword for field-level comments (LF-186)

### DIFF
--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using Bugsnag.Payload;
 using IniParser.Model;
 using LfMerge.Core.Actions;
@@ -220,13 +221,17 @@ namespace LfMerge.Core.Tests
 			LfLexEntry result;
 			if (_storedLfLexEntries.TryGetValue(key, out result))
 				return result;
-			else
-				return null;
+			return null;
 		}
 
 		public IEnumerable<LfOptionList> GetLfOptionLists()
 		{
 			return new List<LfOptionList>(_storedLfOptionLists.Values.Select(entry => DeepCopy(entry)));
+		}
+
+		public IEnumerable<TDocument> GetRecords<TDocument>(ILfProject project, string collectionName, Expression<Func<TDocument, bool>> filter)
+		{
+			return GetRecords<TDocument>(project, collectionName).Where(filter.Compile());
 		}
 
 		public IEnumerable<TDocument> GetRecords<TDocument>(ILfProject project, string collectionName)

--- a/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using MongoDB.Driver;
 using LfMerge.Core.LanguageForge.Config;
 using LfMerge.Core.LanguageForge.Model;
@@ -13,6 +14,7 @@ namespace LfMerge.Core.MongoConnector
 	{
 		IMongoDatabase GetProjectDatabase(ILfProject project);
 		IMongoDatabase GetMainDatabase();
+		IEnumerable<TDocument> GetRecords<TDocument>(ILfProject project, string collectionName, Expression<Func<TDocument, bool>> filter);
 		IEnumerable<TDocument> GetRecords<TDocument>(ILfProject project, string collectionName);
 		LfOptionList GetLfOptionListByCode(ILfProject project, string listCode);
 		long LexEntryCount(ILfProject project);


### PR DESCRIPTION
This change sets the headword for field-level comments when doing
a S/R so that headword shows up in FLEx. This fixes LF-186.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/66)
<!-- Reviewable:end -->
