### PR TITLE
Add and call start script

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -82,10 +82,11 @@ override_dh_auto_install:
 	install -m 644 environ $(DBDESTDIR)/$(SHARE)
 	install -d $(DBDESTDIR)/$(SHARE)/Mercurial/doc
 	install -m 644 Mercurial/doc/*.* $(DBDESTDIR)/$(SHARE)/Mercurial/doc
-	# Install wrapper script
+	# Install wrapper scripts
 	install -d $(COMMONDESTDIR)/usr/bin
 	install -m 755 lfmerge $(COMMONDESTDIR)/usr/bin
 	install -m 755 lfmergeqm $(COMMONDESTDIR)/usr/bin
+	install -m 755 startlfmerge $(DBDESTDIR)/$(LIB)
 	# Install conf file
 	install -d $(COMMONDESTDIR)/etc/languageforge/conf
 	install -m 644 debian/sendreceive.conf $(COMMONDESTDIR)/etc/languageforge/conf

--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -91,13 +91,8 @@ namespace LfMerge.Core
 			Logger.Notice("Starting LfMerge for model version '{0}'", modelVersion);
 			var startInfo = new ProcessStartInfo();
 			var argsBldr = new StringBuilder();
-			if (Platform.IsMono)
-			{
-				startInfo.FileName = "mono";
-				argsBldr.Append("--debug LfMerge.exe");
-			}
-			else
-				startInfo.FileName = "LfMerge.exe";
+			var startInfoWorkingDirectory = GetModelSpecificDirectory(modelVersion);
+			startInfo.FileName = Path.Combine(startInfoWorkingDirectory, "startlfmerge");
 
 			argsBldr.AppendFormat(" -p {0} --action {1}", projectCode, action);
 			if (allowFreshClone)
@@ -110,7 +105,7 @@ namespace LfMerge.Core
 			startInfo.CreateNoWindow = true;
 			startInfo.ErrorDialog = false;
 			startInfo.UseShellExecute = false;
-			startInfo.WorkingDirectory = GetModelSpecificDirectory(modelVersion);
+			startInfo.WorkingDirectory = startInfoWorkingDirectory;
 			try
 			{
 				using (var process = Process.Start(startInfo))

--- a/startlfmerge
+++ b/startlfmerge
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Start LfMerge
+# This script will reside in /usr/lib/lfmerge/<dbversion>/
+
+unset MONO_PREFIX
+unset MONO_ENVIRON
+
+DBVERSION=$(basename $(dirname $(readlink -f $0)))
+
+if [[ $DBVERSION != 70* ]]; then
+	DBVERSION=$(basename $(find /usr/lib/lfmerge -maxdepth 1 -type d -name [0-9]\* | sort | tail -n 1))
+fi
+
+LIB=/usr/lib/lfmerge/$DBVERSION
+SHARE=/usr/share/lfmerge/$DBVERSION
+
+cd "$SHARE"
+RUNMODE=INSTALLED
+. ./environ
+cd "$LIB"
+
+exec mono --debug "$LIB"/LfMerge.exe "$@"


### PR DESCRIPTION
This allows LfMerge to call LfMerge for an older database version
that requires a different version of Mono.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/82)
<!-- Reviewable:end -->
