### PR TITLE
Temporarily change back to use unsecure connection in S/R

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/Infrastructure/ChorusHelperTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/Infrastructure/ChorusHelperTests.cs
@@ -41,7 +41,7 @@ namespace LfMerge.Core.Tests.Actions.Infrastructure
 			var proj = LanguageForgeProject.Create("test");
 			var chorusHelper = MainClass.Container.Resolve<ChorusHelper>();
 			Assert.That(chorusHelper.GetSyncUri(proj),
-				Is.EqualTo("https://x:x@hg-public.languagedepot.org/test"));
+				Is.EqualTo("http://x:x@hg-public.languagedepot.org/test"));
 		}
 
 		[Test]
@@ -50,7 +50,7 @@ namespace LfMerge.Core.Tests.Actions.Infrastructure
 			var proj = LanguageForgeProject.Create("test project");
 			var chorusHelper = MainClass.Container.Resolve<ChorusHelper>();
 			Assert.That(chorusHelper.GetSyncUri(proj),
-				Is.EqualTo("https://x:x@hg-public.languagedepot.org/test+project"));
+				Is.EqualTo("http://x:x@hg-public.languagedepot.org/test+project"));
 		}
 
 		[Test]

--- a/src/LfMerge.Core/LanguageForgeProject.cs
+++ b/src/LfMerge.Core/LanguageForgeProject.cs
@@ -118,9 +118,12 @@ namespace LfMerge.Core
 		{
 			get
 			{
-				string uri = "https://hg-public.languagedepot.org";
+				// temporary change back to use http while we still get invalid certificate from LD
+				//var uri = "https://hg-public.languagedepot.org";
+				var uri = "http://hg-public.languagedepot.org";
 				if (LanguageDepotProject.Repository != null && LanguageDepotProject.Repository.Contains("private"))
-					uri = "https://hg-private.languagedepot.org";
+					//uri = "https://hg-private.languagedepot.org";
+					uri = "http://hg-private.languagedepot.org";
 				return uri;
 			}
 		}


### PR DESCRIPTION
hg-public.languagedepot.org returns an invalid certificate, so a
clone/update fails if we use https. This change switches back to
use http until the certificate issue on the server is fixed.

(cherry picked from commits 7a91508fd670dafa7faa33507dc32e470ce9a261
and e6b4ca7ee71e3badbc81d166c86dad16338dfa33)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/84)
<!-- Reviewable:end -->
