### PR TITLE
Disable global writing system store (LF-297)

### DIFF
--- a/src/LfMerge.Core/FieldWorks/FwProject.cs
+++ b/src/LfMerge.Core/FieldWorks/FwProject.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Xml;
 using LfMerge.Core.Settings;
 using SIL.LCModel;
+using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.Utils;
 
 namespace LfMerge.Core.FieldWorks
@@ -21,6 +22,9 @@ namespace LfMerge.Core.FieldWorks
 
 		public FwProject(LfMergeSettings settings, string database)
 		{
+			// We don't want to use a global writing system store, so we insert a null singleton
+			SingletonsContainer.Add(typeof(CoreGlobalWritingSystemRepository).FullName, null);
+
 			_project = new ProjectIdentifier(settings.LcmDirectorySettings, database);
 			_lcmUi = new ConsoleLcmUi(_progress.SynchronizeInvoke);
 			Cache = TryGetLcmCache();


### PR DESCRIPTION
A global writing system store doesn't make sense in the context of LfMerge where we deal with different independent projects. Disabling it prevents that multiple projects share the same global store.
Part of a fix for LF-297.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/89)
<!-- Reviewable:end -->
