### PR TITLE
Fix wrong SSL certificate fingerprints from LD

### DIFF
--- a/environ
+++ b/environ
@@ -76,4 +76,4 @@ export \
 
 # set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
 # incompatible with our version of Mercurial
-export HGRCPATH=
+export HGRCPATH=/etc/mercurial/hgrc


### PR DESCRIPTION
We're using an old version of Mercurial (3.0) whose SSL implementation does not use Server Name Indication (SNI), so when it connects to https://hg-public.languagedepot.org Apache can't tell what certificate it expects and so gives it the admin.languagedepot.org certificate. Mercurial quite properly complains about that unless you've put a line in its config file under `[hostfingerprints]` explaining what fingerprint you're expecting. Under previous configuration, Mercurial was *only* trusting the `.hg/hgrc` config file in each repo, but it would be a mess to try to update the hgrc config files in every single Send/Receive project each time the SSL fingerprint changes (which will happen every three months since we're using Let's Encrypt). So we are going to put the fingerprint into `/etc/mercurial/hgrc`, and ensure that our environ file allows Mercurial to trust that file. That will keep Send/Receive working for three months at a time (though every time the SSL certificate is renewed we'll have to update `/etc/mercurial/hgrc` on the live server).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/90)
<!-- Reviewable:end -->
