### PR TITLE
Do not convert LIFTid field in entries or senses (master branch)

### DIFF
--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
@@ -279,14 +279,7 @@ namespace LfMerge.Core.DataConverters
 				// LcmEtymology.LiftResidue not mapped
 			}
 			lfEntry.Guid = LcmEntry.Guid;
-			if (LcmEntry.LIFTid == null)
-			{
-				lfEntry.LiftId = null;
-			}
-			else
-			{
-				lfEntry.LiftId = LcmEntry.LIFTid.Normalize(System.Text.NormalizationForm.FormC);  // Because LIFT files on disk are NFC and we need to make sure LiftIDs match those on disk
-			}
+			// LcmEntry.LIFTid not mapped (changed 2019-10 by RM since the LiftId in LF is not useful: see LF-378)
 			lfEntry.LiteralMeaning = ToMultiText(LcmEntry.LiteralMeaning);
 			if (LcmEntry.PrimaryMorphType != null) {
 				lfEntry.MorphologyType = LcmEntry.PrimaryMorphType.NameHierarchyString;
@@ -390,14 +383,7 @@ namespace LfMerge.Core.DataConverters
 
 			lfSense.GeneralNote = ToMultiText(lcmSense.GeneralNote);
 			lfSense.GrammarNote = ToMultiText(lcmSense.GrammarNote);
-			if (lcmSense.LIFTid == null)
-			{
-				lfSense.LiftId = null;
-			}
-			else
-			{
-				lfSense.LiftId = lcmSense.LIFTid.Normalize(System.Text.NormalizationForm.FormC);  // Because LIFT files on disk are NFC and we need to make sure LiftIDs match those on disk
-			}
+			// LcmSense.LIFTid not mapped (changed 2019-10 by RM since the LiftId in LF is not useful: see LF-378)
 			if (lcmSense.MorphoSyntaxAnalysisRA != null)
 			{
 				IPartOfSpeech secondaryPos = null; // Only used in derivational affixes


### PR DESCRIPTION
Language Forge doesn't need it if a GUID is present, and getting the LIFTid from LCM can cause issues if the project had import residue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/95)
<!-- Reviewable:end -->
