### PR TITLE
Fix custom fields bug

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -547,15 +547,10 @@ namespace LfMerge.Core.Tests.Actions
 			var lDLcmEntry = lDcache.ServiceLocator.GetObject(_testEntryGuid) as ILexEntry;
 			var data = (SIL.LCModel.Application.ISilDataAccessManaged)lDcache.DomainDataByFlid;
 			int ownedHvo = data.get_ObjectProp(lDLcmEntry.Hvo, listRef_flid);
-			if (ownedHvo == 0 || !data.get_IsValidObject(ownedHvo))
-			{
-				throw new Exception("Custom field value in test data was invalid during setup");
-			}
+			Assert.AreNotEqual(0, ownedHvo, "Custom field value in test data was invalid during setup");
+			Assert.IsTrue(data.get_IsValidObject(ownedHvo), "Custom field value in test data was invalid during setup");
 			ICmObject referencedObject = lDcache.GetAtomicPropObject(ownedHvo);
-			if (referencedObject == null)
-			{
-				throw new Exception("Custom field in test data referenced invalid CmObject during setup");
-			}
+			Assert.IsNotNull(referencedObject, "Custom field in test data referenced invalid CmObject during setup");
 			DateTime originalLdDateModified = lDLcmEntry.DateModified;
 
 			// Exercise
@@ -568,15 +563,10 @@ namespace LfMerge.Core.Tests.Actions
 			var updatedLcmEntry = lDcache.ServiceLocator.GetObject(_testEntryGuid) as ILexEntry;
 
 			ownedHvo = data.get_ObjectProp(updatedLcmEntry.Hvo, listRef_flid);
-			if (ownedHvo == 0 || !data.get_IsValidObject(ownedHvo))
-			{
-				throw new Exception("Custom field value in test data was invalid after running sync");
-			}
+			Assert.AreNotEqual(0, ownedHvo, "Custom field value in test data was invalid after running sync");
+			Assert.IsTrue(data.get_IsValidObject(ownedHvo), "Custom field value in test data was invalid after running sync");
 			referencedObject = lDcache.GetAtomicPropObject(ownedHvo);
-			if (referencedObject == null)
-			{
-				throw new Exception("Custom field in test data referenced invalid CmObject after running sync");
-			}
+			Assert.IsNotNull(referencedObject, "Custom field in test data referenced invalid CmObject after running sync");
 			var poss = referencedObject as ICmPossibility;
 			// TODO: Write another test to check on the abbrev hierarchy, because we may have a bug here (LfMerge not doing correct optionlist keys for hierarchical items)
 			// Console.WriteLine($"Abbrev hierarchy: {poss.AbbrevHierarchyString}");

--- a/src/LfMerge.Core/DataConverters/ConvertMongoToLcmCustomField.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertMongoToLcmCustomField.cs
@@ -14,6 +14,7 @@ using SIL.LCModel.Core.Cellar;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Text;
 using SIL.LCModel.Infrastructure;
+using SIL.LCModel.DomainServices;
 
 namespace LfMerge.Core.DataConverters
 {
@@ -207,6 +208,12 @@ namespace LfMerge.Core.DataConverters
 					// Oddly, this can return 0 for some custom fields. TODO: Find out why: that seems like it would be an error.
 					if (fieldWs == 0)
 						fieldWs = cache.DefaultUserWs; // TODO: Investigate, because this should probably be wsEn instead so that we can create correct keys.
+					if (fieldWs < 0)
+					{
+						// FindOrCreatePossibility has a bug where it doesn't handle "magic" writing systems (e.g., -1 for default analysis, etc) and
+						// throws an exception instead. So we need to get a real ws here.
+						fieldWs = WritingSystemServices.ActualWs(cache, fieldWs, hvo, flid);
+					}
 					ICmPossibilityList parentList = GetParentListForField(flid);
 					ICmPossibility newPoss = parentList.FindOrCreatePossibility(nameHierarchy, fieldWs);
 


### PR DESCRIPTION
When custom fields referenced a ListReference and there was no GUID in the Mongo data, and the custom field had a wsSelector that was a negative number (a "magic" ws), Send/Receive would crash. This fixes that bug and includes a regression test to ensure the bug stays fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/98)
<!-- Reviewable:end -->
