### PR TITLE
Silence "no config found" warning in unit tests

### DIFF
--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -95,6 +95,16 @@ namespace LfMerge.Core.Tests
 			VerboseProgress = true;
 			PhpSourcePath = Path.Combine(TestEnvironment.FindGitRepoRoot(), "data/php/src");
 		}
+
+		public override IniData ParseFiles(string defaultConfig, string globalConfigFilename)
+		{
+			// Hide the console warning about "no global configuration file found" because we're doing that on purpose
+			var savedStdout = Console.Out;
+			Console.SetOut(TextWriter.Null);
+			IniData result = base.ParseFiles(defaultConfig, globalConfigFilename);
+			Console.SetOut(savedStdout);
+			return result;
+		}
 	}
 
 	public class MongoConnectionDouble: IMongoConnection

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -32,7 +32,7 @@ namespace LfMerge.Core.Settings
 			LcmDirectorySettings = new LcmDirectories();
 
 			// Save parsed config for easier persisting in SaveSettings()
-			ParsedConfig = ParseFiles(DefaultLfMergeSettings.DefaultIniText, ConfigFile);
+			ParsedConfig = this.ParseFiles(DefaultLfMergeSettings.DefaultIniText, ConfigFile);
 			Initialize(ParsedConfig);
 		}
 
@@ -268,7 +268,7 @@ namespace LfMerge.Core.Settings
 			fileParser.WriteFile(fileName, ParsedConfig, utf8);
 		}
 
-		public static IniData ParseFiles(string defaultConfig, string globalConfigFilename)
+		public virtual IniData ParseFiles(string defaultConfig, string globalConfigFilename)
 		{
 			var utf8 = new UTF8Encoding(false);
 			var parserConfig = CreateIniParserConfiguration();


### PR DESCRIPTION
In unit tests where we use an LfMergeSettingsDouble, we deliberately don't use the global configuration, so the warning that LfMergeSettings prints to stdout about it is unnecessary noise. It finally bothered me enough as I ran tests at the console that I did something about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/99)
<!-- Reviewable:end -->
