### PR TITLE
Don't call string.Format twice

### DIFF
--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -146,15 +146,15 @@ namespace LfMerge
 
 				if (project.State.SRState != ProcessingState.SendReceiveStates.ERROR)
 				{
-					MainClass.Logger.Error(string.Format(
+					MainClass.Logger.Error(
 						"Putting project '{0}' on hold due to unhandled exception: \n{1}",
-						projectCode, e));
+						projectCode, e);
 					if (project != null)
 					{
 						project.State.SetErrorState(ProcessingState.SendReceiveStates.HOLD,
-							ProcessingState.ErrorCodes.UnhandledException, string.Format(
+							ProcessingState.ErrorCodes.UnhandledException,
 								"Putting project '{0}' on hold due to unhandled exception: \n{1}",
-								projectCode, e));
+								projectCode, e);
 					}
 				}
 			}


### PR DESCRIPTION
The logger code already calls string.Format on the message and parameters it receives. This is sometimes causing an error about "Input string was not in a correct format" in the second call, when the first string.Format call happens to produce output that contains formatting characters that the second string.Format thinks it should handle. The result is swallowed exceptions. By removing one call to string.Format, we should be able to see the actual exceptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/106)
<!-- Reviewable:end -->
