### PR TITLE
Fix exception in FLEx 8 project upgraded to FLEx 9

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -233,6 +233,73 @@ namespace LfMerge.Core.Tests.Actions
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 
+		public void Success_NewBranchFormat_LfMerge68()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000068}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+		}
+
+		public void Success_NewBranchFormat_LfMerge69()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000069}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			// Stack trace should also have been logged
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
+		}
+
+		[Test]
+		public void Success_NewBranchFormat_LfMerge70()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000070}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
+		}
+
 		[Test]
 		[Ignore("Temporarily disabled - needs updated test data")]
 		public void Success_NoNewChangesFromOthersAndUs()

--- a/src/LfMerge.Core.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/TestEnvironment.cs
@@ -221,6 +221,16 @@ namespace LfMerge.Core.Tests
 				f.Write(bytes, 0, bytes.Length);
 			}
 		}
+
+		public static void WriteTextFile(string fileName, string content, bool append = false, Encoding encoding = null)
+		{
+			if (encoding == null) {
+				encoding = new UTF8Encoding(false);
+			}
+			using (var writer = new StreamWriter(fileName, append, encoding)) {
+				writer.Write(content);
+			}
+		}
 	}
 }
 

--- a/src/LfMerge.Core/Actions/EnsureCloneAction.cs
+++ b/src/LfMerge.Core/Actions/EnsureCloneAction.cs
@@ -153,6 +153,10 @@ namespace LfMerge.Core.Actions
 					}
 
 					var cloneModelVersion = int.Parse(line.Substring(index + modelString.Length, 7));
+					if (cloneModelVersion > MagicStrings.MaximalModelVersion) {
+						// Chorus changed model versions to 75#####.xxxxxxx where xxxxxxx is the old-style model version
+						cloneModelVersion = int.Parse(line.Substring(index + modelString.Length + 8, 7));
+					}
 					if (cloneModelVersion < MagicStrings.MinimalModelVersion)
 					{
 						ReportNoSuchBranchFailure(project, cloneLocation, cloneResult, line, ProcessingState.ErrorCodes.ProjectTooOld);

--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -118,6 +118,10 @@ namespace LfMerge.Core.Actions
 					Require.That(index >= 0);
 
 					var modelVersion = int.Parse(line.Substring(index + cannotCommitCurrentBranch.Length, 7));
+					if (modelVersion > MagicStrings.MaximalModelVersion) {
+						// Chorus changed model versions to 75#####.xxxxxxx where xxxxxxx is the old-style model version
+						modelVersion = int.Parse(line.Substring(index + cannotCommitCurrentBranch.Length + 8, 7));
+					}
 					if (modelVersion < MagicStrings.MinimalModelVersion)
 					{
 						SyncResultedInError(project, syncResult, cannotCommitCurrentBranch,

--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -93,11 +93,21 @@ namespace LfMerge.Core.Actions
 					{"languageDepotRepoUri", chorusHelper.GetSyncUri(project)},
 					{"commitMessage", commitMessage}
 				};
-				if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Send_Receive", Progress,
-					options, out syncResult))
-				{
-					Logger.Error(syncResult);
-					return;
+
+				try {
+					if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Send_Receive", Progress,
+						options, out syncResult))
+					{
+						Logger.Error(syncResult);
+						return;
+					}
+				} catch (System.FormatException e) {
+					if (e.StackTrace.Contains("System.Int32.Parse")) {
+						ChorusHelper.SetModelVersion(MagicStrings.MinimalModelVersionForNewBranchFormat);
+						return;
+					} else {
+						throw;
+					}
 				}
 
 				const string cannotCommitCurrentBranch = "Cannot commit to current branch '";

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -107,6 +107,8 @@ namespace LfMerge.Core
 		{
 			MinimalModelVersion = minimalModelVersion;
 		}
+
+		public const int MaximalModelVersion = 7499999;
 	}
 }
 

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -100,6 +100,8 @@ namespace LfMerge.Core
 
 		public static string[] UnsupportedModelVersions { get; } = { "7000071" };
 
+		public const int MinimalModelVersionForNewBranchFormat = 7000072;
+
 		// Allow to set minimal model version during unit testing
 		public static void SetMinimalModelVersion(int minimalModelVersion)
 		{


### PR DESCRIPTION
Due to an internal change in the Send/Receive system, when a FLEx 8 project upgrades to FLEx 9, LfMerge throws an unhandled exception in the Send/Receive process. This should fix that issue by forcing LfMerge to retry the Send/Receive with the FLEx 9 code if that happens.

Fixes #107.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/108)
<!-- Reviewable:end -->
