### PR TITLE
Bugfix: Correct example sentence magic string

### DIFF
--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -83,7 +83,7 @@ namespace LfMerge.Core
 
 		// Field names to use in an LfCommentRegarding instance
 		public const string LfFieldNameForDefinition = "definition";
-		public const string LfFieldNameForExampleSentence = "definition";
+		public const string LfFieldNameForExampleSentence = "sentence";
 
 		// Fake language codes used in storing custom GenDate and int fields in Mongo
 		public const string LanguageCodeForGenDateFields = "qaa-Qaad";


### PR DESCRIPTION
When reviewing code on a different PR, I noticed that the value of `LFFieldNameForExampleSentence` was set to `definition` when it most definitely should be set to `sentence`.  This looks wrong and is likely the result of a copy/paste error (from the line above).  I have no way to test this, and this PR doesn't fix a known bug.  However, it seems so obviously wrong that I got up the guts to create this PR :)

Fixes #109 

References in web-languageforge to support this PR:

- https://github.com/sillsdev/web-languageforge/blob/master/src/angular-app/languageforge/lexicon/shared/model/lex-example.model.ts#L7https://github.com/sillsdev/web-languageforge/blob/master/src/Api/Model/Languageforge/Lexicon/LexExample.php#L144
- 