### PR TITLE
Update GitVersion tool and config

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "gitversion.tool": {
-      "version": "5.3.7",
+      "version": "5.6.9",
       "commands": [
         "dotnet-gitversion"
       ]

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,16 +5,16 @@ branches:
     tag:
     regex: (origin/)?(fieldworks8-)?live
     is-mainline: true
-    is-source-branch-for: [ 'master' ]
-    source-branches: [ 'master', 'qa' ]
+    is-source-branch-for: [ 'main' ]
+    source-branches: [ 'main', 'qa' ]
   qa:
     mode: ContinuousDeployment
     track-merge-target: true
     tag: beta
     regex: (origin/)?(fieldworks8-)?qa
-    is-source-branch-for: [ 'master', 'live' ]
-    source-branches: [ 'master' ]
-  master:
+    is-source-branch-for: [ 'main', 'live' ]
+    source-branches: [ 'main' ]
+  main:
     mode: ContinuousDeployment
     track-merge-target: true
     tag: alpha
@@ -26,6 +26,6 @@ branches:
     tag: PR
     regex: (origin/)?PR
     tag-number-pattern: '[/-](?<number>\d+)[-/]'
-    source-branches: [ 'master', 'qa', 'live' ]
+    source-branches: [ 'main', 'qa', 'live' ]
 ignore:
   sha: []


### PR DESCRIPTION
At some point recently, GitVersion changed the name of the `master` branch to `main`, and if we run `dotnet gitversion` with our current config we get a KeyNotFoundException with the message "The given key 'master' was not present in the dictionary." Changing `master` to `main` everywhere except the branch-name-matching regex fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/111)
<!-- Reviewable:end -->
