### PR TITLE
Use dotnet-gitversion tool in FW8 build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "5.6.9",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,23 +1,31 @@
 mode: Mainline
+continuous-delivery-fallback-tag: dev
 branches:
   live:
     tag:
     regex: (origin/)?(fieldworks8-)?live
     is-mainline: true
+    is-source-branch-for: [ 'main' ]
+    source-branches: [ 'main', 'qa' ]
   qa:
     mode: ContinuousDeployment
     track-merge-target: true
     tag: beta
     regex: (origin/)?(fieldworks8-)?qa
-  master:
+    is-source-branch-for: [ 'main', 'live' ]
+    source-branches: [ 'main' ]
+  main:
     mode: ContinuousDeployment
     track-merge-target: true
     tag: alpha
     regex: (origin/)?(fieldworks8-)?master
+    is-source-branch-for: [ 'qa' ]
   pull-request:
     mode: ContinuousDeployment
     track-merge-target: true
     tag: PR
     regex: (origin/)?(PR|pr)
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    source-branches: [ 'main', 'qa', 'live' ]
 ignore:
   sha: []


### PR DESCRIPTION
This is #111 but applied to the fieldworks8-master branch so that Jenkins can build that branch again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/113)
<!-- Reviewable:end -->
