### PR TITLE
Fix exception in FLEx 8 project upgraded to FLEx 9

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="TeamCity" value="http://build.palaso.org/guestAuth/app/nuget/v1/FeedService.svc/" />
+  </packageSources>
+</configuration>

--- a/build/LfMerge.dep
+++ b/build/LfMerge.dep
@@ -73,8 +73,8 @@ L10NSharp.pdb=>lib/
 
 [TC::FLExBridgeLfmergeLinux64Continuous]
 Name=FLEx Bridge-lfmerge-Linux64-Continuous
-RevisionName=lastSuccessful
-RevisionValue=latest.lastSuccessful
+RevisionName=lastPinned
+RevisionValue=latest.lastPinned
 Condition=Linux
 Path=LibFLExBridge-ChorusPlugin.*=>lib/
 LibTriboroughBridge-ChorusPlugin.*=>lib/

--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -13,12 +13,6 @@
 		<DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(PackageSources)' == '' ">
-		<!-- Package sources used to restore packages. -->
-		<!-- The official NuGet package source (https://nuget.org/api/v2/) will be excluded if package sources are specified and it does not appear in the list -->
-		<PackageSource Include="https://nuget.org/api/v2/" />
-		<PackageSource Include="http://build.palaso.org/guestAuth/app/nuget/v1/FeedService.svc/" />
-	</ItemGroup>
 
 	<PropertyGroup>
 		<NuGetToolsPath>$(MSBuildThisFileDirectory)</NuGetToolsPath>
@@ -26,7 +20,7 @@
 		<!-- NuGet command -->
 		<NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)/nuget.exe</NuGetExePath>
 
-		<PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
+		<!-- <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources> -->
 
 		<NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
 		<NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">$(NuGetToolsPath)/nuget</NuGetCommand>
@@ -56,7 +50,7 @@
 	</Target>
 
 	<Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
-		<Exec Command='$(NuGetCommand) restore -MSBuildVersion 14 -NonInteractive -Source "$(PackageSources)" "$(SolutionPath)"'/>
+		<Exec Command='$(NuGetCommand) restore -MSBuildVersion 14 -NonInteractive "$(SolutionPath)"'/>
 	</Target>
 
 	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory"

--- a/environ
+++ b/environ
@@ -1,14 +1,14 @@
 #!/bin/sh
 # Environment settings for running programs with the SIL version of mono
 # Set MONO_ENVIRON to this file's pathname, then run, for example,
-#    /opt/mono-sil/bin/mono --debug LfMerge.exe
-# These settings assume that the packaged SIL Mono is installed in /opt/mono-sil.
+#    /opt/mono5-sil/bin/mono --debug LfMerge.exe
+# These settings assume that the packaged SIL Mono is installed in /opt/mono5-sil.
 # Note that this file is intended to be "sourced", not "executed".
 
 # the sourcing script should cd/pushd to the directory containing this script
 BASE="$(pwd)"
 [ -z "$BUILD" ] && BUILD=Debug
-[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono-sil
+[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono5-sil
 
 MONO_RUNTIME=v4.0.30319
 MONO_DEBUG=explicit-null-checks
@@ -41,10 +41,10 @@ fi
 if [ "$RUNMODE" = "PACKAGE" -o "$RUNMODE" = "INSTALLED" ]
 then
 	# Add packaged mono items to paths
-	PATH="/opt/mono-sil/bin:${PATH}"
-	LD_LIBRARY_PATH="/opt/mono-sil/lib:${LD_LIBRARY_PATH}"
-	PKG_CONFIG_PATH="/opt/mono-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
-	MONO_GAC_PREFIX="/opt/mono-sil:/usr"
+	PATH="/opt/mono5-sil/bin:${PATH}"
+	LD_LIBRARY_PATH="/opt/mono5-sil/lib:${LD_LIBRARY_PATH}"
+	PKG_CONFIG_PATH="/opt/mono5-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	MONO_GAC_PREFIX="/opt/mono5-sil:/usr"
 else
 	# Add locally-built mono items to paths
 	# We also add the default values for PKG_CONFIG_PATH - MonoDevelop resets the PKG_CONFIG_PATH

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -229,6 +229,73 @@ namespace LfMerge.Core.Tests.Actions
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 
+		public void Success_NewBranchFormat_LfMerge68()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000068}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+		}
+
+		public void Success_NewBranchFormat_LfMerge69()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000069}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			// Stack trace should also have been logged
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
+		}
+
+		[Test]
+		public void Success_NewBranchFormat_LfMerge70()
+		{
+			// Setup
+			var ldDirectory = CopyModifiedProjectAsTestLangProj(_lDSettings.WebWorkDirectory);
+			TestEnvironment.CopyFwProjectTo(TestLangProj, _env.Settings.WebWorkDirectory);
+			TestEnvironment.WriteTextFile(Path.Combine(_env.Settings.WebWorkDirectory, TestLangProj, "FLExProject.ModelVersion"), "{\"modelversion\": 7000070}");
+			LanguageDepotMock.Server.Start();
+			var oldHashOfLd = MercurialTestHelper.GetRevisionOfTip(ldDirectory);
+
+			// Execute
+			_synchronizeAction.Run(_lfProject);
+
+			// Verify
+			Assert.That(MercurialTestHelper.GetRevisionOfWorkingSet(_lfProject.ProjectDir),
+				Is.EqualTo(MercurialTestHelper.GetRevisionOfTip(ldDirectory)),
+				"Our repo doesn't have the changes from LanguageDepot");
+			Assert.That(MercurialTestHelper.GetRevisionOfTip(ldDirectory), Is.EqualTo(oldHashOfLd));
+			Assert.That(_env.Logger.GetErrors(), Is.Null.Or.Empty);
+			Assert.That(_env.Logger.GetMessages(), Is.StringContaining("Received changes from others"));
+			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
+		}
+
 		[Test]
 		public void Success_NoNewChangesFromOthersAndUs()
 		{

--- a/src/LfMerge.Core.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/TestEnvironment.cs
@@ -212,6 +212,16 @@ namespace LfMerge.Core.Tests
 			}
 		}
 
+		public static void WriteTextFile(string fileName, string content, bool append = false, Encoding encoding = null)
+		{
+			if (encoding == null) {
+				encoding = new UTF8Encoding(false);
+			}
+			using (var writer = new StreamWriter(fileName, append, encoding)) {
+				writer.Write(content);
+			}
+		}
+
 //		public string WriteFile(string fileName, string xmlForEntries, string directory)
 //		{
 //			string content;

--- a/src/LfMerge.Core/Actions/EnsureCloneAction.cs
+++ b/src/LfMerge.Core/Actions/EnsureCloneAction.cs
@@ -153,6 +153,10 @@ namespace LfMerge.Core.Actions
 					}
 
 					var cloneModelVersion = line.Substring(index + modelString.Length, 7);
+					if (int.Parse(cloneModelVersion) > int.Parse(MagicStrings.MaximalModelVersion)) {
+						// Chorus changed model versions to 75#####.xxxxxxx where xxxxxxx is the old-style model version
+						cloneModelVersion = line.Substring(index + modelString.Length + 8, 7);
+					}
 					if (int.Parse(cloneModelVersion) < int.Parse(MagicStrings.MinimalModelVersion))
 					{
 						ReportNoSuchBranchFailure(project, cloneLocation, cloneResult, line, ProcessingState.ErrorCodes.ProjectTooOld);

--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -94,18 +94,24 @@ namespace LfMerge.Core.Actions
 					{"commitMessage", commitMessage}
 				};
 
-				try {
+				try
+				{
 					if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Send_Receive", Progress,
 						options, out syncResult))
 					{
 						Logger.Error(syncResult);
 						return;
 					}
-				} catch (System.FormatException e) {
-					if (e.StackTrace.Contains("System.Int32.Parse")) {
+				}
+				catch (System.FormatException e)
+				{
+					if (e.StackTrace.Contains("System.Int32.Parse"))
+					{
 						ChorusHelper.SetModelVersion(MagicStrings.MinimalModelVersionForNewBranchFormat.ToString());
 						return;
-					} else {
+					}
+					else
+					{
 						throw;
 					}
 				}

--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -93,11 +93,21 @@ namespace LfMerge.Core.Actions
 					{"languageDepotRepoUri", chorusHelper.GetSyncUri(project)},
 					{"commitMessage", commitMessage}
 				};
-				if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Send_Receive", Progress,
-					options, out syncResult))
-				{
-					Logger.Error(syncResult);
-					return;
+
+				try {
+					if (!LfMergeBridge.LfMergeBridge.Execute("Language_Forge_Send_Receive", Progress,
+						options, out syncResult))
+					{
+						Logger.Error(syncResult);
+						return;
+					}
+				} catch (System.FormatException e) {
+					if (e.StackTrace.Contains("System.Int32.Parse")) {
+						ChorusHelper.SetModelVersion(MagicStrings.MinimalModelVersionForNewBranchFormat.ToString());
+						return;
+					} else {
+						throw;
+					}
 				}
 
 				const string cannotCommitCurrentBranch = "Cannot commit to current branch '";

--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -124,6 +124,10 @@ namespace LfMerge.Core.Actions
 					Require.That(index >= 0);
 
 					var modelVersion = line.Substring(index + cannotCommitCurrentBranch.Length, 7);
+					if (int.Parse(modelVersion) > int.Parse(MagicStrings.MaximalModelVersion)) {
+						// Chorus changed model versions to 75#####.xxxxxxx where xxxxxxx is the old-style model version
+						modelVersion = line.Substring(index + cannotCommitCurrentBranch.Length + 8, 7);
+					}
 					if (int.Parse(modelVersion) < int.Parse(MagicStrings.MinimalModelVersion))
 					{
 						SyncResultedInError(project, syncResult, cannotCommitCurrentBranch,

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -98,6 +98,8 @@ namespace LfMerge.Core
 		// Minimal supported model version (static property to support testing)
 		public static string MinimalModelVersion { get; private set; }
 
+		public const int MinimalModelVersionForNewBranchFormat = 7000072;
+
 		// Allow to set minimal model version during unit testing
 		public static void SetMinimalModelVersion(string minimalModelVersion)
 		{

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -105,6 +105,9 @@ namespace LfMerge.Core
 		{
 			MinimalModelVersion = minimalModelVersion;
 		}
+
+		// Maximal supported model version (7500000 and above are for a different Chorus version)
+		public const string MaximalModelVersion = "7499999";
 	}
 }
 


### PR DESCRIPTION
Due to an internal change in the Send/Receive system, when a FLEx 8 project upgrades to FLEx 9, LfMerge throws an unhandled exception in the Send/Receive process. This should fix that issue by forcing LfMerge to retry the Send/Receive with the FLEx 9 code if that happens.

Fixes #107.

**NOTE:** This is #108 applied to the correct branch (this fix needs to be in the older versions of LfMerge, and it doesn't hurt to have it on `master` as well so I'll leave #108 open).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/114)
<!-- Reviewable:end -->
