### PR TITLE
Fix packaging build in Jenkins

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -18,6 +18,8 @@ COMMONDESTDIR	= debian/lfmerge
 LIB				= usr/lib/lfmerge/__DatabaseVersion__
 SHARE			= usr/share/lfmerge/__DatabaseVersion__
 
+export DBVERSIONPATH=/usr/lib/lfmerge/__DatabaseVersion__
+
 define MERCURIAL_INI
 [extensions]
 eol=


### PR DESCRIPTION
The Jenkins autopackager build agents don't have `/usr/lib/lfmerge/7*` directories, so the part of the `environ` script that tries to set `DBVERSIONPATH` is apparently failing, leading to build failures during packaging. This should ensure that it's set correctly during the Debian packaging step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/115)
<!-- Reviewable:end -->
