### PR TITLE
Restore NuGet packages inside project root

### DIFF
--- a/build/LfMerge.proj
+++ b/build/LfMerge.proj
@@ -3,6 +3,7 @@
 		<RootDir Condition="'$(RootDir)'==''">$(MSBuildProjectDirectory)/..</RootDir>
 		<Solution>LfMerge.sln</Solution>
 		<SolutionPath>$(RootDir)/$(Solution)</SolutionPath>
+		<RestorePackagesPath>$(RootDir)/packages</RestorePackagesPath>
 		<ApplicationName>LfMerge</ApplicationName>
 		<ApplicationNameLC>lfmerge</ApplicationNameLC>
 		<Configuration Condition="'$(Configuration)'==''">Release</Configuration>

--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -43,7 +43,7 @@
 
 	<Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
 		<Exec
-			Command='$(NuGetCommand) restore -NonInteractive "$(SolutionPath)"'/>
+			Command='$(NuGetCommand) restore -NonInteractive "$(SolutionPath)" -OutputDirectory packages'/>
 	</Target>
 
 	<Target Name="_DownloadNuGet" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')">


### PR DESCRIPTION
This should allow the Debian source package to contain the downloaded NuGet package files, so that the MsBuild process running inside the schroot on Jenkins will still be able to find and use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/116)
<!-- Reviewable:end -->
