### PR TITLE
Fix package build

### DIFF
--- a/build/LfMerge.proj
+++ b/build/LfMerge.proj
@@ -83,9 +83,9 @@
 		<CallTarget Targets="CompileOnly"/>
 	</Target>
 
-	<Target Name="CompileOnly">
+	<Target Name="CompileOnly" DependsOnTargets="RestorePackages">
 		<!-- This target gets called during binary package build and shouldn't download
-			anything -->
+			anything (restore is ok if packages already exist in $(RootDir)/packages)-->
 		<MSBuild
 			Projects="$(SolutionPath)"
 			Targets="Build"

--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -5,6 +5,7 @@
 
 		<!-- Enable the restore command to run before builds -->
 		<RestorePackages Condition="  '$(RestorePackages)' == '' ">true</RestorePackages>
+		<RestorePackagesPath Condition=" '$(RestorePackagesPath)' == ''">packages</RestorePackagesPath>
 
 		<!-- Determines if package restore consent is required to restore packages -->
 		<RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">false</RequireRestoreConsent>
@@ -43,7 +44,7 @@
 
 	<Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
 		<Exec
-			Command='$(NuGetCommand) restore -NonInteractive "$(SolutionPath)" -OutputDirectory packages'/>
+			Command='$(NuGetCommand) restore -NonInteractive -OutputDirectory "$(RestorePackagesPath)" "$(SolutionPath)"'/>
 	</Target>
 
 	<Target Name="_DownloadNuGet" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')">

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -37,13 +37,13 @@ override_dh_auto_configure:
 override_dh_auto_build:
 	. ./environ && \
 		which $(MSBUILD) && \
-		$(MSBUILD) /p:Configuration=$(BUILD) /p:DatabaseVersion=__DatabaseVersion__ /p:DisableGitVersionTask=true /t:CompileOnly build/LfMerge.proj
+		$(MSBUILD) /p:Configuration=$(BUILD) /p:DatabaseVersion=__DatabaseVersion__ /p:DisableGitVersionTask=true /p:GenerateAssemblyInfo=false /t:CompileOnly build/LfMerge.proj
 
 override_dh_auto_test:
 
 override_dh_auto_clean:
 	. ./environ && \
-		$(MSBUILD) /p:Configuration=$(BUILD) /p:DisableGitVersionTask=true /t:Clean build/LfMerge.proj
+		$(MSBUILD) /p:Configuration=$(BUILD) /p:DisableGitVersionTask=true /p:GenerateAssemblyInfo=false /t:Clean build/LfMerge.proj
 	dh_clean
 
 override_dh_auto_install:


### PR DESCRIPTION
- Fix package build
- Don't generate assembly info during package build

During a package build when we call CompileOnly we have to restore packages even when they already exist in `$(RootDir)/packages`. The reason is that the source package doesn't include the `obj` directories which contain some information about the packages that the build needs to find dependencies. However, those files in `obj` contain absolute paths so we can't add them to the source package. Instead we call RestorePackages again which will recreate the `obj` directories, but doesn't download anything from the Internet.

Also, the working directory seems to be different so we have to pass in a full path as the location for the packages.

As part of creating the source package we let GitVersion update the `AssemblyInfo.cs` files. When we later create the binary
package we shouldn't let msbuild generate assemblyinfo metadata because that results in duplicate attributes (CS0579).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/117)
<!-- Reviewable:end -->
