### PR TITLE
Enable data migration on new Chorus branches

### DIFF
--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -107,7 +107,15 @@ namespace LfMerge.Core.Actions
 				{
 					if (e.StackTrace.Contains("System.Int32.Parse"))
 					{
-						ChorusHelper.SetModelVersion(MagicStrings.MinimalModelVersionForNewBranchFormat.ToString());
+						var modelVersion = MagicStrings.MinimalModelVersionForNewBranchFormat.ToString();
+						ChorusHelper.SetModelVersion(modelVersion);
+#if FW8_COMPAT
+						// The .hg branch has a higher model version than the .fwdata file. We allow
+						// data migrations and try again.
+						Logger.Notice("Allow data migration for project '{0}' to migrate to model version '{1}'",
+							project.ProjectCode, modelVersion);
+						FwProject.AllowDataMigration = true;
+#endif
 						return;
 					}
 					else
@@ -127,6 +135,13 @@ namespace LfMerge.Core.Actions
 					if (int.Parse(modelVersion) > int.Parse(MagicStrings.MaximalModelVersion)) {
 						// Chorus changed model versions to 75#####.xxxxxxx where xxxxxxx is the old-style model version
 						modelVersion = line.Substring(index + cannotCommitCurrentBranch.Length + 8, 7);
+#if FW8_COMPAT
+						// The .hg branch has a higher model version than the .fwdata file. We allow
+						// data migrations and try again.
+						Logger.Notice("Allow data migration for project '{0}' to migrate to model version '{1}'",
+							project.ProjectCode, modelVersion);
+						FwProject.AllowDataMigration = true;
+#endif
 					}
 					if (int.Parse(modelVersion) < int.Parse(MagicStrings.MinimalModelVersion))
 					{


### PR DESCRIPTION
As the code currently stands, it won't throw when you Send/Receive a FW8 project that has been converted to FW9, but the data migration won't run either. This fixes that omission.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/118)
<!-- Reviewable:end -->
