### PR TITLE
Make iputils-ping a package, not dev, dependency (FW8 branch)

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -7,7 +7,6 @@ Homepage: https://languageforge.org/
 Vcs-Git: git://github.com/sillsdev/LfMerge.git
 Vcs-Browser: https://github.com/sillsdev/LfMerge
 Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
- iputils-ping,
  wget,
  mercurial,
  python-dev,
@@ -39,6 +38,7 @@ Description: LanguageForge Send/Receive
 Package: lfmerge-__DatabaseVersion__
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
+ iputils-ping,
  pkg-config,
  mono-sil,
  lfmerge-fdo-__DatabaseVersion__


### PR DESCRIPTION
If ping is not present at runtime, Chorus fails to send anything. In some Docker deployments, the `iputils-ping` package is not installed by default, so we need `lfmerge` to depend in `iputils-ping` so that it will install correct dependencies in Docker/Kubernetes environments.

This is https://github.com/sillsdev/LfMerge/pull/120 applied against `fieldworks8-master`. Both PRs should be merged together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/121)
<!-- Reviewable:end -->
