### PR TITLE
Use env vars to specify Language Depot hostname

### DIFF
--- a/src/LfMerge.Core/LanguageForgeProject.cs
+++ b/src/LfMerge.Core/LanguageForgeProject.cs
@@ -118,10 +118,11 @@ namespace LfMerge.Core
 		{
 			get
 			{
-				string uri = "https://hg-public.languagedepot.org";
+				string hostname = System.Environment.GetEnvironmentVariable("LD_HG_PUBLIC_HOSTNAME") ?? "hg-public.languagedepot.org";
+				string protocol = System.Environment.GetEnvironmentVariable("LD_HG_PROTOCOL") ?? "https";
 				if (LanguageDepotProject.Repository != null && LanguageDepotProject.Repository.Contains("private"))
-					uri = "https://hg-private.languagedepot.org";
-				return uri;
+					hostname = System.Environment.GetEnvironmentVariable("LD_HG_PRIVATE_HOSTNAME") ?? hostname.Replace("public", "private");
+				return string.Format("{0}://{1}", protocol, hostname);
 			}
 		}
 


### PR DESCRIPTION
Three new environment variables will be used for LfMerge settings:
- LD_HG_PUBLIC_HOSTNAME defaults to hg-public.languagedepot.org
- LD_HG_PRIVATE_HOSTNAME defaults to hg-private.languagedepot.org
- LD_HG_PROTOCOL defaults to https

This will allow Docker setups to more easily use a QA/staging Language Depot setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/123)
<!-- Reviewable:end -->
