### PR TITLE
Add LD_TRUST_TOKEN environment variable

### DIFF
--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -28,6 +28,10 @@ namespace LfMerge.Core.Actions.Infrastructure
 				Password = Password,
 				Path = HttpUtility.UrlEncode(project.LanguageDepotProject.Identifier)
 			};
+			var trustToken = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN");
+			if (!string.IsNullOrEmpty(trustToken)) {
+				uriBldr.Query = $"trust_token={trustToken}";
+			}
 			return uriBldr.Uri.ToString();
 		}
 


### PR DESCRIPTION
Used for adding a trust_token query parameter to Mercurial URLs, which Language Depot will use to determine that the request came from the Language Forge server. (IP address checking doesn't work well with Kubernetes deployments, where the IP address can change frequently).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/126)
<!-- Reviewable:end -->
