### PR TITLE
Add LD_TRUST_TOKEN environment variable

### DIFF
--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -27,6 +27,10 @@ namespace LfMerge.Core.Actions.Infrastructure
 				Password = Password,
 				Path = HttpUtilityFromMono.UrlEncode(project.LanguageDepotProject.Identifier)
 			};
+			var trustToken = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN");
+			if (!string.IsNullOrEmpty(trustToken)) {
+				uriBldr.Query = $"trust_token={trustToken}";
+			}
 			return uriBldr.Uri.ToString();
 		}
 


### PR DESCRIPTION
Used for adding a trust_token query param to Mercurial URLs, which Language Depot will use to determine that the request came from the Language Forge server. (IP address checking doesn't work well with Kubernetes deployments, where the IP address can change frequently).

This is https://github.com/sillsdev/LfMerge/pull/126 targeted at `fieldworks8-master` rather than `master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/127)
<!-- Reviewable:end -->
