### PR TITLE
Use LD_TRUST_TOKEN as Mercurial password

### DIFF
--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -13,7 +13,7 @@ namespace LfMerge.Core.Actions.Infrastructure
 		static ChorusHelper()
 		{
 			Username = "x";
-			Password = "x";
+			Password = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN") ?? "x";
 		}
 
 		public virtual string GetSyncUri(ILfProject project)
@@ -27,10 +27,6 @@ namespace LfMerge.Core.Actions.Infrastructure
 				Password = Password,
 				Path = HttpUtilityFromMono.UrlEncode(project.LanguageDepotProject.Identifier)
 			};
-			var trustToken = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN");
-			if (!string.IsNullOrEmpty(trustToken)) {
-				uriBldr.Query = $"trust_token={trustToken}";
-			}
 			return uriBldr.Uri.ToString();
 		}
 


### PR DESCRIPTION
Mercurial doesn't accept query strings in repo URIs, so we have to submit the trust token as a password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/128)
<!-- Reviewable:end -->
