### PR TITLE
Use LD_TRUST_TOKEN as Mercurial password

### DIFF
--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -14,7 +14,7 @@ namespace LfMerge.Core.Actions.Infrastructure
 		static ChorusHelper()
 		{
 			Username = "x";
-			Password = "x";
+			Password = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN") ?? "x";
 		}
 
 		public virtual string GetSyncUri(ILfProject project)
@@ -28,10 +28,6 @@ namespace LfMerge.Core.Actions.Infrastructure
 				Password = Password,
 				Path = HttpUtility.UrlEncode(project.LanguageDepotProject.Identifier)
 			};
-			var trustToken = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN");
-			if (!string.IsNullOrEmpty(trustToken)) {
-				uriBldr.Query = $"trust_token={trustToken}";
-			}
 			return uriBldr.Uri.ToString();
 		}
 


### PR DESCRIPTION
Mercurial doesn't accept query strings in repo URIs, so we have to submit the trust token as a password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/129)
<!-- Reviewable:end -->
