### PR TITLE
Update GitVersion to 5.7.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "gitversion.tool": {
-      "version": "5.6.10",
+      "version": "5.7.0",
       "commands": [
         "dotnet-gitversion"
       ]

--- a/LfMerge.TestApp/LfMerge.TestApp.csproj
+++ b/LfMerge.TestApp/LfMerge.TestApp.csproj
@@ -31,7 +31,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/FixFwData/FixFwData.csproj
+++ b/src/FixFwData/FixFwData.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.LCModel.FixData" Version="10.1.0-beta0382" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />

--- a/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
+++ b/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
@@ -29,7 +29,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.2.1510.2205" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="3.5.2" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="icu.net" Version="2.6.0" />
     <PackageReference Include="INIFileParserDotNetCore.Signed" Version="2.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/LfMerge.Tests/LfMerge.Tests.csproj
+++ b/src/LfMerge.Tests/LfMerge.Tests.csproj
@@ -30,7 +30,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -38,7 +38,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/LfMergeAuxTool/LfMergeAuxTool.csproj
+++ b/src/LfMergeAuxTool/LfMergeAuxTool.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/LfMergeQueueManager/LfMergeQueueManager.csproj
+++ b/src/LfMergeQueueManager/LfMergeQueueManager.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10" PrivateAssets="All" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.7.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
There seems to be a GitVersion bug that is moving the HEAD of the Git repo during a build, which among other things means that the `git reset` step in our Jenkins build jumps back to a commit from a couple months ago, and doesn't actually build the current version. https://github.com/GitTools/GitVersion/issues/2554 suggests that it might have been introduced in GitVersion 5.6.4, so if 5.7.0 doesn't work then I'm going to move back to 5.6.3 and try that version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/130)
<!-- Reviewable:end -->
