### PR TITLE
Deal with multiple writing systems with same tag

### DIFF
--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
@@ -612,9 +612,9 @@ namespace LfMerge.Core.DataConverters
 				};
 
 				#if FW8_COMPAT
-				lfWsList.Add(LcmWs.Id, lfWs);
+				lfWsList[LcmWs.Id] = lfWs;
 				#else
-				lfWsList.Add(LcmWs.LanguageTag, lfWs);
+				lfWsList[LcmWs.LanguageTag] = lfWs;
 				#endif
 			}
 			return lfWsList;


### PR DESCRIPTION
Occasionally there's a project with malformed data where two different writing systems have the same tag. We don't try to fix that data, we just ensure that LfMerge will be able to carry on without throwing an exception in that instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/141)
<!-- Reviewable:end -->
