### PR TITLE
Fix fieldworks8-master build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Check out FW8 branch
         uses: actions/checkout@v2
-        if: github.event_name == 'push' && matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'
+        if: github.event_name == 'push' && !startsWith(github.ref_name, 'fieldworks8-') && matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'
         with:
           ref: fieldworks8-${{ github.ref_name }}
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that


### PR DESCRIPTION
The code that checks out the fieldworks8-{ref_name} branch should only
run when the workflow is running on master/qa/live. When running on
fieldworks8-* branches, it's already checking out the right branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/148)
<!-- Reviewable:end -->
