### PR TITLE
Ensure DB version 72 doesn't run on FW8 branches

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Decide if this build configuration should run
         id: should_run
         run: true
-        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && !startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion >= 7000072) }}
+        if: ${{ (github.event_name == 'push' && !startsWith(github.ref_name, 'fieldworks8-')) || (github.event_name == 'push' && startsWith(github.ref_name, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && !startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion >= 7000072) }}
 
       - name: Check out current branch
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixed a missing condition in the should_run step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/149)
<!-- Reviewable:end -->
