### PR TITLE
Update AssemblyInfo files manually in FW8 builds

### DIFF
--- a/.github/workflows/trythis.yml
+++ b/.github/workflows/trythis.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get output version
         env:
-          VERSION: ${{ steps.id_version.outputs.version || steps.branch_version.outputs.version || steps.pr_version.outputs.version || 'no version found' }}
+          VERSION: ${{ steps.tag_version.outputs.version || steps.branch_version.outputs.version || steps.pr_version.outputs.version || 'no version found' }}
         run: echo "Version calculated as ${VERSION}"
 
       - name: Calculate version in one step

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000068
 ENV DbVersion=7000068
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000068
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # To run specific unit tests, set TEST_SPEC env var, e.g.:
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
@@ -38,6 +39,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000069
 ENV DbVersion=7000069
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000069
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 
@@ -45,6 +47,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000070
 ENV DbVersion=7000070
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000070
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 
@@ -52,6 +55,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000072
 ENV DbVersion=7000072
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000072
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=0
 ENV NUNIT_VERSION_MAJOR=3
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,10 +36,7 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
-	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
-	find src -name AssemblyInfo.cs -path '*LfMerge*'
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
-		echo "Will update AssemblyInfo.cs files"
 		find src -name AssemblyInfo.cs -path '*LfMerge*' -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
 	fi
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -40,7 +40,7 @@ cd -
 	find src -name AssemblyInfo.cs
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
 		echo "Will update AssemblyInfo.cs files"
-		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ./update-assemblyinfo.sh
+		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/update-assemblyinfo.sh
 	fi
 
 	cat > NuGet.Config <<EOF

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,6 +36,10 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
+	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
+		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ./update-assemblyinfo.sh
+	fi
+
 	cat > NuGet.Config <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,13 +36,6 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
-	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
-	find src -name AssemblyInfo.cs -not -path FixFwData
-	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
-		echo "Will update AssemblyInfo.cs files"
-		find src -name AssemblyInfo.cs -not -path FixFwData -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
-	fi
-
 	cat > NuGet.Config <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -40,7 +40,7 @@ cd -
 	find src -name AssemblyInfo.cs
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
 		echo "Will update AssemblyInfo.cs files"
-		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/update-assemblyinfo.sh
+		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
 	fi
 
 	cat > NuGet.Config <<EOF

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,7 +36,10 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
+	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
+	find src -name AssemblyInfo.cs
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
+		echo "Will update AssemblyInfo.cs files"
 		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ./update-assemblyinfo.sh
 	fi
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -37,10 +37,10 @@ cd -
 	git reset --hard
 
 	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
-	find src -name AssemblyInfo.cs -not -path FixFwData
+	find src -name AssemblyInfo.cs -path '*LfMerge*'
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
 		echo "Will update AssemblyInfo.cs files"
-		find src -name AssemblyInfo.cs -not -path FixFwData -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
+		find src -name AssemblyInfo.cs -path '*LfMerge*' -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
 	fi
 
 	cat > NuGet.Config <<EOF

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,6 +36,13 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
+	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
+	find src -name AssemblyInfo.cs -not -path FixFwData
+	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
+		echo "Will update AssemblyInfo.cs files"
+		find src -name AssemblyInfo.cs -not -path FixFwData -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
+	fi
+
 	cat > NuGet.Config <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -37,10 +37,10 @@ cd -
 	git reset --hard
 
 	echo "AssemblyInfo files that would be updated if '$UPDATE_ASSEMBLYINFO_BY_SCRIPT' is not '' or '0':"
-	find src -name AssemblyInfo.cs
+	find src -name AssemblyInfo.cs -not -path FixFwData
 	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
 		echo "Will update AssemblyInfo.cs files"
-		find src -name AssemblyInfo.cs -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
+		find src -name AssemblyInfo.cs -not -path FixFwData -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
 	fi
 
 	cat > NuGet.Config <<EOF

--- a/docker/scripts/update-assemblyinfo.sh
+++ b/docker/scripts/update-assemblyinfo.sh
@@ -25,6 +25,8 @@ FileVersion=${FileVersion:-$(echo "$Version" | sed -E 's/^([^-]*)+.*/\1/')}
 tmpfname="$(mktemp)"
 fname="$1"
 
+echo "Updating ${fname} with AssemblyVersion ${AssemblyVersion} and InformationalVersion ${InformationalVersion}"
+
 # First remove any existing lines
 cat "$fname" \
 | sed '/^\[assembly: AssemblyVersion("[^"]*")\]$/d' \

--- a/docker/scripts/update-assemblyinfo.sh
+++ b/docker/scripts/update-assemblyinfo.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ $# -le 0 ]; then
+	echo "Error: no filename given. Please pass a filename on the command line."
+	exit 1
+fi
+if [ $# -gt 1 ]; then
+	echo "Warning: multiple filenames passed. Only $1 will be processed." >&2
+fi
+
+# Rules for auto-generated AssemblyInfo in .Net Core 3.1 or later, which we will replicate:
+# AssemblyVersion and FileVersion default to the value of $(Version) without the suffix. For example, if $(Version) is 1.2.3-beta.4, then the value would be 1.2.3.
+# InformationalVersion defaults to the value of $(Version).
+# Source: https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generateassemblyinfo
+
+Version=${Version:-0.0.1}
+
+InformationalVersion=${InformationalVersion:-$Version}
+AssemblyVersion=${AssemblyVersion:-$(echo "$Version" | sed -E 's/^([^-]*)+.*/\1/')}
+FileVersion=${FileVersion:-$(echo "$Version" | sed -E 's/^([^-]*)+.*/\1/')}
+
+# Assembly attribute lines look like this:
+# [assembly: AssemblyVersion("1.2.3.4")]
+
+tmpfname="$(mktemp)"
+fname="$1"
+
+# First remove any existing lines
+cat "$fname" \
+| sed '/^\[assembly: AssemblyVersion("[^"]*")\]$/d' \
+| sed '/^\[assembly: AssemblyFileVersion("[^"]*")\]$/d' \
+| sed '/^\[assembly: AssemblyInformationalVersion("[^"]*")\]$/d' \
+> "$tmpfname"
+
+# Then append new lines at the end
+echo "[assembly: AssemblyVersion(\"${AssemblyVersion}\")]" >> "$tmpfname"
+echo "[assembly: AssemblyFileVersion(\"${FileVersion}\")]" >> "$tmpfname"
+echo "[assembly: AssemblyInformationalVersion(\"${InformationalVersion}\")]" >> "$tmpfname"
+
+mv "${tmpfname}" "${fname}"


### PR DESCRIPTION
The GenerateAssemblyInfo feature came in with .Net Core 3.1. Anything built with Mono 5 won't have it, so for the FW8 builds we need to update AssemblyInfo.cs files ourselves. I haven't found a good GHA action for that, so we'll do it ourselves with a simple bash script. The bash script will reorder lines in the file, but that's not a big deal, and it keeps it very simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/152)
<!-- Reviewable:end -->
