### PR TITLE
No more checking out the Dockerfile in FW8 builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,12 +130,6 @@ jobs:
       # TODO: Step that calculates version number from `git-describe` and prerelease name based on branch
       # That will allow us to ditch GitVersion, which is randomly failing on some PR builds with no rhyme or reason
 
-      - name: Check out files needed for Docker build if on older branches
-        # TODO: Will not be needed once Docker build is merged into fieldworks8-master
-        if: matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'
-        run:
-          git checkout refs/remotes/origin/master -- docker Dockerfile
-
       - name: Build base Docker image
         if: steps.should_run.outcome == 'success'
         run: docker build -t lfmerge-builder-base --target lfmerge-builder-base .


### PR DESCRIPTION
The fieldworks8-master branch now needs its own version of the
Dockerfile, because it needs to have some code (adjusting the
AssemblyInfo.cs files) that's not needed in the master branch. Checking
out the master branch copy was causing PR 152 not to actually build what
I thought it was building.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/153)
<!-- Reviewable:end -->
