### PR TITLE
Update AssemblyInfo files manually in FW8 builds

### DIFF
--- a/.github/workflows/trythis.yml
+++ b/.github/workflows/trythis.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get output version
         env:
-          VERSION: ${{ steps.id_version.outputs.version || steps.branch_version.outputs.version || steps.pr_version.outputs.version || 'no version found' }}
+          VERSION: ${{ steps.tag_version.outputs.version || steps.branch_version.outputs.version || steps.pr_version.outputs.version || 'no version found' }}
         run: echo "Version calculated as ${VERSION}"
 
       - name: Calculate version in one step

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000068
 ENV DbVersion=7000068
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000068
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # To run specific unit tests, set TEST_SPEC env var, e.g.:
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
@@ -38,6 +39,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000069
 ENV DbVersion=7000069
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000069
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 
@@ -45,6 +47,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000070
 ENV DbVersion=7000070
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000070
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 
@@ -52,6 +55,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000072
 ENV DbVersion=7000072
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000072
 ENV RUN_UNIT_TESTS=0
+ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=0
 ENV NUNIT_VERSION_MAJOR=3
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -36,6 +36,10 @@ cd -
 	git clean -dxf --exclude=packages/ --exclude=lib/
 	git reset --hard
 
+	if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
+		find src -name AssemblyInfo.cs -path '*LfMerge*' -print0 | xargs -0 -n 1 ${HOME}/packages/lfmerge/docker/scripts/update-assemblyinfo.sh
+	fi
+
 	cat > NuGet.Config <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>

--- a/docker/scripts/update-assemblyinfo.sh
+++ b/docker/scripts/update-assemblyinfo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ $# -le 0 ]; then
+	echo "Error: no filename given. Please pass a filename on the command line."
+	exit 1
+fi
+if [ $# -gt 1 ]; then
+	echo "Warning: multiple filenames passed. Only $1 will be processed." >&2
+fi
+
+# Rules for auto-generated AssemblyInfo in .Net Core 3.1 or later, which we will replicate:
+# AssemblyVersion and FileVersion default to the value of $(Version) without the suffix. For example, if $(Version) is 1.2.3-beta.4, then the value would be 1.2.3.
+# InformationalVersion defaults to the value of $(Version).
+# Source: https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generateassemblyinfo
+
+Version=${Version:-0.0.1}
+
+InformationalVersion=${InformationalVersion:-$Version}
+AssemblyVersion=${AssemblyVersion:-$(echo "$Version" | sed -E 's/^([^-]*)+.*/\1/')}
+FileVersion=${FileVersion:-$(echo "$Version" | sed -E 's/^([^-]*)+.*/\1/')}
+
+# Assembly attribute lines look like this:
+# [assembly: AssemblyVersion("1.2.3.4")]
+
+tmpfname="$(mktemp)"
+fname="$1"
+
+echo "Updating ${fname} with AssemblyVersion ${AssemblyVersion} and InformationalVersion ${InformationalVersion}"
+
+# First remove any existing lines
+cat "$fname" \
+| sed '/^\[assembly: AssemblyVersion("[^"]*")\]$/d' \
+| sed '/^\[assembly: AssemblyFileVersion("[^"]*")\]$/d' \
+| sed '/^\[assembly: AssemblyInformationalVersion("[^"]*")\]$/d' \
+> "$tmpfname"
+
+# Then append new lines at the end
+echo "[assembly: AssemblyVersion(\"${AssemblyVersion}\")]" >> "$tmpfname"
+echo "[assembly: AssemblyFileVersion(\"${FileVersion}\")]" >> "$tmpfname"
+echo "[assembly: AssemblyInformationalVersion(\"${InformationalVersion}\")]" >> "$tmpfname"
+
+mv "${tmpfname}" "${fname}"


### PR DESCRIPTION
The GenerateAssemblyInfo feature came in with .Net Core 3.1. Anything built with Mono 5 won't have it, so for the FW8 builds we need to update AssemblyInfo.cs files ourselves. I haven't found a good GHA action for that, so we'll do it ourselves with a simple bash script. The bash script will reorder lines in the file, but that's not a big deal, and it keeps it very simple.

This PR ensures that the `fieldworks8-master` and `master` branches have the exact same build process, with the only differences controlled by conditionals and environment variables instead of having two different build workflows.

Eventually I plan to switch to having a single [reusable workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) kept in the `master` branch, which will be *called* via `workflow_call` from all the other branches, to ensure that there's a Single Source of Truth™ for the build process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/154)
<!-- Reviewable:end -->
