### PR TITLE
Optimize Docker caching in build process

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -151,6 +151,10 @@ jobs:
           build-args: |
             DbVersion=${{matrix.dbversion}}
 
+      - name: Run docker image ls to verify build
+        if: steps.should_run.outcome == 'success'
+        run: docker image ls
+
       - name: Run the build container
         if: steps.should_run.outcome == 'success'
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -144,7 +144,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
-          tags: lfmerge-build-${{matrix.dbversion}}
+          tags: lfmerge-build-${{matrix.dbversion}}:latest
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -161,7 +161,7 @@ jobs:
           AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
           AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+        run: docker run --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}:latest
 
       - name: Collect Debian images
         if: steps.should_run.outcome == 'success'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -140,6 +140,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: false
+          load: true
           tags: lfmerge-build-${{matrix.dbversion}}:latest
           context: .
           cache-from: type=gha

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -135,10 +135,6 @@ jobs:
       - name: Set up buildx for Docker
         uses: docker/setup-buildx-action@v1
 
-      - name: Build base Docker image
-        if: steps.should_run.outcome == 'success'
-        run: docker build -t lfmerge-builder-base --target lfmerge-builder-base .
-
       - name: Build DBVersion-specific Docker image
         if: steps.should_run.outcome == 'success'
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -132,12 +132,6 @@ jobs:
           echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
           echo "::set-output name=InformationalVersion::${InformationalVersion}"
 
-      - name: Check out files needed for Docker build if on older branches
-        # TODO: Will not be needed once Docker build is merged into fieldworks8-master
-        if: matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'
-        run:
-          git checkout refs/remotes/origin/master -- docker Dockerfile
-
       - name: Build base Docker image
         if: steps.should_run.outcome == 'success'
         run: docker build -t lfmerge-builder-base --target lfmerge-builder-base .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           push: false
           load: true
-          tags: lfmerge-build-${{matrix.dbversion}}:latest
+          tags: lfmerge-build-${{matrix.dbversion}}
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -162,7 +162,7 @@ jobs:
           AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
           AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}:latest
+        run: docker run --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
       - name: Collect Debian images
         if: steps.should_run.outcome == 'success'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -132,13 +132,24 @@ jobs:
           echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
           echo "::set-output name=InformationalVersion::${InformationalVersion}"
 
+      - name: Set up buildx for Docker
+        uses: docker/setup-buildx-action@v1
+
       - name: Build base Docker image
         if: steps.should_run.outcome == 'success'
         run: docker build -t lfmerge-builder-base --target lfmerge-builder-base .
 
       - name: Build DBVersion-specific Docker image
         if: steps.should_run.outcome == 'success'
-        run: docker build --build-arg DbVersion=${{matrix.dbversion}} -t lfmerge-build-${{matrix.dbversion}} .
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: lfmerge-build-${{matrix.dbversion}}
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DbVersion=${{matrix.dbversion}}
 
       - name: Run the build container
         if: steps.should_run.outcome == 'success'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -132,9 +132,6 @@ jobs:
           echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
           echo "::set-output name=InformationalVersion::${InformationalVersion}"
 
-      # TODO: Step that calculates version number from `git-describe` and prerelease name based on branch
-      # That will allow us to ditch GitVersion, which is randomly failing on some PR builds with no rhyme or reason
-
       - name: Check out files needed for Docker build if on older branches
         # TODO: Will not be needed once Docker build is merged into fieldworks8-master
         if: matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'


### PR DESCRIPTION
We'll use https://github.com/docker/build-push-action to take advantage of GitHub's caching API and hopefully speed up the steps that build the Docker images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/155)
<!-- Reviewable:end -->
