### PR TITLE
Optimize Docker caching in build process

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -127,16 +127,25 @@ jobs:
           echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
           echo "::set-output name=InformationalVersion::${InformationalVersion}"
 
-      # TODO: Step that calculates version number from `git-describe` and prerelease name based on branch
-      # That will allow us to ditch GitVersion, which is randomly failing on some PR builds with no rhyme or reason
-
-      - name: Build base Docker image
-        if: steps.should_run.outcome == 'success'
-        run: docker build -t lfmerge-builder-base --target lfmerge-builder-base .
+      - name: Set up buildx for Docker
+        uses: docker/setup-buildx-action@v1
 
       - name: Build DBVersion-specific Docker image
         if: steps.should_run.outcome == 'success'
-        run: docker build --build-arg DbVersion=${{matrix.dbversion}} -t lfmerge-build-${{matrix.dbversion}} .
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: lfmerge-build-${{matrix.dbversion}}
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DbVersion=${{matrix.dbversion}}
+
+      - name: Run docker image ls to verify build
+        if: steps.should_run.outcome == 'success'
+        run: docker image ls
 
       - name: Run the build container
         if: steps.should_run.outcome == 'success'


### PR DESCRIPTION
We'll use https://github.com/docker/build-push-action to take advantage of GitHub's caching API and speed up the Docker image build steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/156)
<!-- Reviewable:end -->
