### PR TITLE
Sign Debian packages when creating them

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -152,17 +152,30 @@ jobs:
         if: steps.should_run.outcome == 'success'
         run: docker image ls
 
+      - name: Create and populate secrets folder
+        if: steps.should_run.outcome == 'success'
+        env:
+          SIGNING_KEY: ${{ secrets.PACKAGE_SIGNING_KEY_SIMPLE }}
+        run: |
+          mkdir -p secrets
+          echo "${SIGNING_KEY}" > secrets/signing_key.sec.asc
+
       - name: Run the build container
         if: steps.should_run.outcome == 'success'
         env:
           BUILD_NUMBER: ${{ github.run_number }}
+          DEB_SIGN_KEYID: AD15E4A69D9750B3AEBC9DF06E0BC361361C1AED
           DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
           MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
           MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
           AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
           AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+        run: docker run --mount type=bind,source="$(pwd)/secrets",target=/secrets,readonly --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DEB_SIGN_KEYID=${DEB_SIGN_KEYID}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+
+      - name: Delete secrets folder
+        if: always()
+        run: rm -rf secrets
 
       - name: Collect Debian images
         if: steps.should_run.outcome == 'success'

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -56,7 +56,7 @@ EOF
 	echo -e "\033[0;34mBuild source package\033[0m"
 	TRACE $HOME/ci-builder-scripts/bash/make-source --dists "$DistributionsToPackage" \
 		--arches "amd64" --main-package-name "lfmerge" --source-code-subdir "." \
-		--supported-distros "xenial bionic" --debkeyid $DEBSIGNKEY \
+		--supported-distros "xenial bionic" --debkeyid $DEB_SIGN_KEYID \
 		--package-version "$DebPackageVersion" --preserve-changelog
 
 	# echo -e "\033[0;34mBuild binary package\033[0m"

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -5,7 +5,7 @@ echo -e "\033[0;34mBuilding packages for version ${DebPackageVersion} (inserted 
 #DistributionsToPackage="xenial bionic"
 DistributionsToPackage="bionic"
 
-DEBSIGNKEY=BB89B185D63A1DD5
+gpg --import /secrets/*asc || true
 
 # Needed in setup.sh from Debian packaging scripts. TODO: Investigate why this environment variable is being removed, and at what point
 export USER=root


### PR DESCRIPTION
Note that we create the secrets folder as late as possible, and delete it as soon as possible, *even* if the build fails. Don't want anything to accidentally collect the secret key as a build artifact due to a mistyped glob pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/157)
<!-- Reviewable:end -->
