### PR TITLE
Create GitHub release automatically

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -174,4 +174,52 @@ jobs:
           name: lfmerge-deb-files
           path: finalresults/lfmerge*deb
 
-      # TODO: If `live` branch, then create release
+    outputs:
+      MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/live'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Ensure release number exists
+      # Will throw an error, thereby cancelling the build, if MajorMinorPatch output was empty
+      env:
+        MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
+      run: test -n "${MajorMinorPatch}" && echo "Producing release ${MajorMinorPatch}"
+
+    - name: Tag new release
+      env:
+        MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git tag -a -m "Release v${MajorMinorPatch}" "v${MajorMinorPatch}"
+        git push --tags
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: lfmerge-deb-files
+        path: release
+
+    - name: Create GitHub release
+      env:
+        MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{needs.build.outputs.MajorMinorPatch}}
+        files: release/*.deb
+        body: |
+          # LfMerge v${{needs.build.outputs.MajorMinorPatch}}
+
+          First release via GitHub Releases
+
+          ## To install
+
+          Download all the .deb files, then make sure the `gdebi-core` package is installed. Then run `gdebi lfmerge*.deb`.
+


### PR DESCRIPTION
The first release will use a manually-created body. After that I will replace the `body: ...` in the YAML with `generate_release_notes: true` which will use GitHub's handy auto-generated release notes, that consist of one line per PR with the PR name and author (and a link to the PR), plus a link to the differences between the previous tag and this one. But I want at least one release with a manually-generated content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/158)
<!-- Reviewable:end -->
