### PR TITLE
Sync fieldworks8-master and master workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,22 +20,10 @@ jobs:
         distro: [ 'bionic' ]
 
     steps:
-      - name: Dump GitHub context for testing
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
-      - name: Echo dbversion and current ref
-        env:
-          DBVERSION: ${{ matrix.dbversion }}
-          REFNAME: ${{ github.ref_name }}
-          BASEREF: ${{ github.base_ref }}
-        run: echo "DB version ${DBVERSION} and ref ${GITHUB_REF} (ref name ${REFNAME} and base ref ${BASEREF}) with current SHA ${GITHUB_SHA}"
-
       - name: Decide if this build configuration should run
         id: should_run
         run: true
-        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && !startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion >= 7000072) }}
+        if: ${{ (github.event_name == 'push' && !startsWith(github.ref_name, 'fieldworks8-')) || (github.event_name == 'push' && startsWith(github.ref_name, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && !startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion >= 7000072) }}
 
       - name: Check out current branch
         uses: actions/checkout@v2


### PR DESCRIPTION
The "should this workflow run" conditional has had a minor change in the fieldworks8-master branch that was not yet pulled into the master branch. While we're at it, we shouldn't dump the `github` context to the logs carelessly, because it does contain some sensitive info like the GITHUB_TOKEN value. It's automatically redacted in the GitHub logs, but in case a bug makes that redaction fail, we don't want to expose it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/159)
<!-- Reviewable:end -->
