### PR TITLE
Tag fieldworks8-live builds, but do not release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -168,7 +168,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/live'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -189,13 +189,17 @@ jobs:
         git tag -a -m "Release v${MajorMinorPatch}" "v${MajorMinorPatch}"
         git push --tags
 
+    # On fieldworks8-live branch, we stop there and don't create a GitHub release
+
     - name: Download build artifacts
+      if: github.ref == 'refs/heads/live'
       uses: actions/download-artifact@v2
       with:
         name: lfmerge-deb-files
         path: release
 
     - name: Create GitHub release
+      if: github.ref == 'refs/heads/live'
       env:
         MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,9 +55,12 @@ jobs:
           MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
           PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
           # TODO: Detect need for minor/major updates and increment those instead of PATCH
-          PATCH=$((${PATCH} + 1))
           COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
           COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
+          if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
+            # If we're building from a tagged version, rebuild precisely that version
+            PATCH=$((${PATCH} + 1))
+          fi
           MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
           AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
           AssemblySemFileVer="${MajorMinorPatch}.0"


### PR DESCRIPTION
Any time the `fieldworks8-live` build runs, we do need to push its Git tag so that subsequent builds will pick up on the new tag.

This PR also fixes a potential race condition that could have existed between the `fieldworks8-live` and `live` branch builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/161)
<!-- Reviewable:end -->
