### PR TITLE
Tag fieldworks8-live builds, but do not release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,9 +55,12 @@ jobs:
           MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
           PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
           # TODO: Detect need for minor/major updates and increment those instead of PATCH
-          PATCH=$((${PATCH} + 1))
           COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
           COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
+          if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
+            # If we're building from a tagged version, rebuild precisely that version
+            PATCH=$((${PATCH} + 1))
+          fi
           MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
           AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
           AssemblySemFileVer="${MajorMinorPatch}.0"
@@ -168,7 +171,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/live'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -189,13 +192,17 @@ jobs:
         git tag -a -m "Release v${MajorMinorPatch}" "v${MajorMinorPatch}"
         git push --tags
 
+    # On fieldworks8-live branch, we stop there and don't create a GitHub release
+
     - name: Download build artifacts
+      if: github.ref == 'refs/heads/live'
       uses: actions/download-artifact@v2
       with:
         name: lfmerge-deb-files
         path: release
 
     - name: Create GitHub release
+      if: github.ref == 'refs/heads/live'
       env:
         MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* Tag fieldworks8-live builds, but do not release

Any time the fieldworks8-live build runs, we do need to push its Git tag
so that subsequent builds will pick up on the new tag

* Prevent potential race condition in tagging

If a fieldworks8-live build is kicked off and allowed to run to
completion before a live build is kicked off, the following could
happen:

- fw8-live build completes, tags v1.5.25 (for example)
- live build checks out fw8-live branch
- live build finds v1.5.25 tag, calculates new version number 1.5.26
- live build creates release with 1.5.26 packages in it

Later, another build is kicked off where fieldworks8-live and live
branches are pushed almost simultaneously, resulting in the following
build order:

- live build checks out fw8-live branch
- live build finds v1.5.25 tag, because v1.5.26 tag not yet in fw8-live
- live build creates release with 1.5.26 packages in it
- fw8-live build completes, tags v1.5.26

Result: two releases were created with lfmerge-fw8 packages at v1.5.26.

To avoid this potential issue, we only increment the patch number if
there has been at least one commit since the latest tag, otherwise if
we're building from a tagged commit then we rebuild the exact same
version number on that tagged commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/162)
<!-- Reviewable:end -->
