### PR TITLE
Make workflow safe to run locally (no git reset)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -147,6 +147,10 @@ jobs:
         if: steps.should_run.outcome == 'success'
         run: docker image ls
 
+      - name: Create sentinel file
+        if: steps.should_run.outcome == 'success'
+        run: touch it-worked.txt
+
       - name: Run the build container
         if: steps.should_run.outcome == 'success'
         env:
@@ -162,6 +166,10 @@ jobs:
       - name: Collect Debian images
         if: steps.should_run.outcome == 'success'
         run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/finalresults ./
+
+      - name: Verify sentinel file is still there
+        if: steps.should_run.outcome == 'success'
+        run: test -f it-worked.txt
 
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -147,10 +147,6 @@ jobs:
         if: steps.should_run.outcome == 'success'
         run: docker image ls
 
-      - name: Create sentinel file
-        if: steps.should_run.outcome == 'success'
-        run: touch it-worked.txt
-
       - name: Run the build container
         if: steps.should_run.outcome == 'success'
         env:
@@ -166,10 +162,6 @@ jobs:
       - name: Collect Debian images
         if: steps.should_run.outcome == 'success'
         run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/finalresults ./
-
-      - name: Verify sentinel file is still there
-        if: steps.should_run.outcome == 'success'
-        run: test -f it-worked.txt
 
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -159,6 +159,10 @@ jobs:
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
+      - name: Collect Debian images
+        if: steps.should_run.outcome == 'success'
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/finalresults ./
+
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
         if: steps.should_run.outcome == 'success'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,7 +157,7 @@ jobs:
           AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
           AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/packages/lfmerge --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ USER builder
 
 # Git repo should be mounted under ${HOME}/packages/lfmerge when run
 # E.g., `docker run --mount type=bind,source="$(pwd)",target=/home/builder/packages/lfmerge`
-RUN mkdir -p /home/builder/packages/lfmerge
-CMD /home/builder/packages/lfmerge/docker/scripts/build-and-test.sh ${DbVersion}
+RUN mkdir -p /home/builder/repo /home/builder/packages/lfmerge
+CMD /home/builder/repo/docker/scripts/build-and-test.sh ${DbVersion}
 # CMD doesn't actually run the script, it just gives `docker run` a default.
 # So it's okay for the Git repo to not be mounted yet.

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -7,8 +7,10 @@ echo "Building for ${DbVersion}"
 sudo mkdir -p /usr/lib/lfmerge/${DbVersion}
 
 # Assuming script is being run from inside the repo, find the repo root and use that as the working directory from now on
+echo "Script dir is ${SCRIPT_DIR}"
 cd "${SCRIPT_DIR}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+echo "Repo root is ${REPO_ROOT}"
 cd "${REPO_ROOT}"
 
 "$SCRIPT_DIR"/setup-workspace.sh "${HOME}/packages/lfmerge"

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -6,12 +6,14 @@ export DbVersion="${1-7000072}"
 echo "Building for ${DbVersion}"
 sudo mkdir -p /usr/lib/lfmerge/${DbVersion}
 
-# Assumptions:
-# - Git repo is mounted under ${HOME}/packages/lfmerge
-# - Scripts live in ${HOME}/packages/lfmerge/docker/scripts
-cd /home/builder/packages/lfmerge
+# Assuming script is being run from inside the repo, find the repo root and use that as the working directory from now on
+cd "${SCRIPT_DIR}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
 
-"$SCRIPT_DIR"/setup-workspace.sh ${DBVersion}
+"$SCRIPT_DIR"/setup-workspace.sh "${REPO_ROOT}"
+
+echo After setup-workspace.sh, pwd is $(pwd)
 
 "$SCRIPT_DIR"/gitversion-combined.sh ${DbVersion}
 

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -11,7 +11,7 @@ cd "${SCRIPT_DIR}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
-"$SCRIPT_DIR"/setup-workspace.sh "${REPO_ROOT}"
+"$SCRIPT_DIR"/setup-workspace.sh "${HOME}/packages/lfmerge"
 
 echo After setup-workspace.sh, pwd is $(pwd)
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -23,8 +23,6 @@ cd ${HOME}/packages/lfmerge
 mkdir -p finalresults
 rm -f finalresults/*
 rm -f lfmerge-*
-echo "DEBUG: pwd && ls -lR"
-pwd && ls -lR
 export MONO_PREFIX=/opt/mono5-sil
 RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -23,7 +23,8 @@ cd ${HOME}/packages/lfmerge
 mkdir -p finalresults
 rm -f finalresults/*
 rm -f lfmerge-*
-
+echo "DEBUG: pwd && ls -lR"
+pwd && ls -lR
 export MONO_PREFIX=/opt/mono5-sil
 RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -27,8 +27,6 @@ rm -f lfmerge-*
 export MONO_PREFIX=/opt/mono5-sil
 RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 
-cd -
-
 # for ((curDbVersion=7000068; curDbVersion<=7000070; curDbVersion++)); do
 	echo -e "\033[0;34mBuilding package for database version ${curDbVersion}\033[0m"
 

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -9,9 +9,9 @@ mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
 echo "Inside setup-workspace.sh, pwd is $(pwd) and repo root is ${REPO_ROOT}"
 
-echo 'DEBUG: ls -lR ${DEST}'
+echo 'DEBUG: ls -lR ${DEST}' which is "${DEST}"
 ls -lR "${DEST}"
-echo 'DEBUG: ls -lR ${REPO_ROOT}'
+echo 'DEBUG: ls -lR ${REPO_ROOT}' which is "${REPO_ROOT}"
 ls -lR "${REPO_ROOT}"
 sudo cp -a "${REPO_ROOT}" "${DEST}"
 sudo chown -R builder:users "${DEST}"

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -7,17 +7,10 @@ export MONO_PREFIX=/opt/mono5-sil
 mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-echo "Inside setup-workspace.sh, pwd is $(pwd) and repo root is ${REPO_ROOT}"
 
-echo 'DEBUG: ls -lR ${DEST}' which is "${DEST}"
-ls -lR "${DEST}"
-echo 'DEBUG: ls -lR ${REPO_ROOT}' which is "${REPO_ROOT}"
-ls -lR "${REPO_ROOT}"
 # cp -a "${REPO_ROOT}" "${DEST}" creates ${DEST}/repo and then everything is under there. That's not actually what we want. So...
 sudo cp -a "${REPO_ROOT}"/* "${REPO_ROOT}"/.[a-zA-Z0-9]* "${DEST}"
 sudo chown -R builder:users "${DEST}"
-echo 'DEBUG: ls -lR ${DEST}'
-ls -lR "${DEST}"
 # The make-source shell script (and its common.sh helper) expects to live under ${HOME}/ci-builder-scripts/bash, so make sure that's the case
 mkdir -p "${HOME}/ci-builder-scripts/bash"
 cp "${DEST}/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
@@ -26,8 +19,6 @@ cp "${DEST}/docker/make-source" "${HOME}/ci-builder-scripts/bash/"
 cd "${DEST}"
 git clean -dxf --exclude=packages/
 git reset --hard
-echo 'DEBUG: ls -lR ${DEST} after git clean'
-ls -lR "${DEST}"
 
 # FLExBridge dependencies from FW 8 builds have vanished from TeamCity, so we stored them in the Docker image under ${REPO_ROOT}/docker
 mkdir -p lib

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -9,7 +9,8 @@ mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
 sudo cp -a "${REPO_ROOT}" "${DEST}"
 sudo chown -R builder:users "${DEST}"
-
+echo 'DEBUG: ls -lR ${DEST}'
+ls -lR "${DEST}"
 # The make-source shell script (and its common.sh helper) expects to live under ${HOME}/ci-builder-scripts/bash, so make sure that's the case
 mkdir -p "${HOME}/ci-builder-scripts/bash"
 cp "${DEST}/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
@@ -18,6 +19,8 @@ cp "${DEST}/docker/make-source" "${HOME}/ci-builder-scripts/bash/"
 cd "${DEST}"
 git clean -dxf --exclude=packages/
 git reset --hard
+echo 'DEBUG: ls -lR ${DEST} after git clean'
+ls -lR "${DEST}"
 
 # FLExBridge dependencies from FW 8 builds have vanished from TeamCity, so we stored them in the Docker image under ${REPO_ROOT}/docker
 mkdir -p lib

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -7,6 +7,8 @@ export MONO_PREFIX=/opt/mono5-sil
 mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
+echo "Inside setup-workspace.sh, pwd is $(pwd) and repo root is ${REPO_ROOT}"
+
 sudo cp -a "${REPO_ROOT}" "${DEST}"
 sudo chown -R builder:users "${DEST}"
 echo 'DEBUG: ls -lR ${DEST}'

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -6,7 +6,7 @@ export MONO_PREFIX=/opt/mono5-sil
 
 mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 
-REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 echo "Inside setup-workspace.sh, pwd is $(pwd) and repo root is ${REPO_ROOT}"
 
 echo 'DEBUG: ls -lR ${DEST}' which is "${DEST}"

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -13,7 +13,8 @@ echo 'DEBUG: ls -lR ${DEST}' which is "${DEST}"
 ls -lR "${DEST}"
 echo 'DEBUG: ls -lR ${REPO_ROOT}' which is "${REPO_ROOT}"
 ls -lR "${REPO_ROOT}"
-sudo cp -a "${REPO_ROOT}" "${DEST}"
+# cp -a "${REPO_ROOT}" "${DEST}" creates ${DEST}/repo and then everything is under there. That's not actually what we want. So...
+sudo cp -a "${REPO_ROOT}"/* "${REPO_ROOT}"/.[a-zA-Z0-9]* "${DEST}"
 sudo chown -R builder:users "${DEST}"
 echo 'DEBUG: ls -lR ${DEST}'
 ls -lR "${DEST}"

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -1,31 +1,24 @@
 #!/bin/bash
 
-# Assumptions:
-# - Git repo is mounted under ${HOME}/packages/lfmerge
-# - fw8-flexbridge.tar.xz dependency is mounted under ${HOME}/dependencies
+DEST="${1:-${HOME}/packages/lfmerge}"
 
 export MONO_PREFIX=/opt/mono5-sil
 
-mkdir -p ${HOME}/.gnupg ${HOME}/ci-builder-scripts/bash ${HOME}/packages/lfmerge
+mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
-sudo cp -a "${REPO_ROOT}" "${HOME}/packages/lfmerge"
-sudo chown -R builder:users "${HOME}/packages/lfmerge"
-
-cd "${HOME}/packages/lfmerge"
-git clean -dxf --exclude=packages/
-git reset --hard
-
-echo Inside setup-workspace.sh, pwd is $(pwd)
-
-# Instead of downloading FLExBridge DLLs which have vanished from TeamCity, store them in the Docker image
-mkdir -p lib
-cp "${HOME}/dependencies/fw8-flexbridge.tar.xz lib/"
-
-# TODO: Consider running a package restore here so that it's cached in the build image instead of having to run in the container each time
-# E.g., call download-dependencies-combined.sh at this point
+sudo cp -a "${REPO_ROOT}" "${DEST}"
+sudo chown -R builder:users "${DEST}"
 
 # The make-source shell script (and its common.sh helper) expects to live under ${HOME}/ci-builder-scripts/bash, so make sure that's the case
 mkdir -p "${HOME}/ci-builder-scripts/bash"
-cp "${HOME}/packages/lfmerge/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
-cp "${HOME}/packages/lfmerge/docker/make-source" "${HOME}/ci-builder-scripts/bash/"
+cp "${DEST}/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
+cp "${DEST}/docker/make-source" "${HOME}/ci-builder-scripts/bash/"
+
+cd "${DEST}"
+git clean -dxf --exclude=packages/
+git reset --hard
+
+# FLExBridge dependencies from FW 8 builds have vanished from TeamCity, so we stored them in the Docker image under ${REPO_ROOT}/docker
+mkdir -p lib
+(cd lib && xz -d "${REPO_ROOT}/docker/fw8-flexbridge.tar.xz" | tar xf -)

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -30,4 +30,4 @@ ls -lR "${DEST}"
 
 # FLExBridge dependencies from FW 8 builds have vanished from TeamCity, so we stored them in the Docker image under ${REPO_ROOT}/docker
 mkdir -p lib
-(cd lib && xz -d "${REPO_ROOT}/docker/fw8-flexbridge.tar.xz" | tar xf -)
+(cd lib && xz -dc "${REPO_ROOT}/docker/fw8-flexbridge.tar.xz" | tar xf -)

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -8,20 +8,24 @@ export MONO_PREFIX=/opt/mono5-sil
 
 mkdir -p ${HOME}/.gnupg ${HOME}/ci-builder-scripts/bash ${HOME}/packages/lfmerge
 
-sudo chown -R builder:users ${HOME}/packages/lfmerge
+REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
+sudo cp -a "${REPO_ROOT}" "${HOME}/packages/lfmerge"
+sudo chown -R builder:users "${HOME}/packages/lfmerge"
 
-cd ${HOME}/packages/lfmerge
+cd "${HOME}/packages/lfmerge"
 git clean -dxf --exclude=packages/
 git reset --hard
 
+echo Inside setup-workspace.sh, pwd is $(pwd)
+
 # Instead of downloading FLExBridge DLLs which have vanished from TeamCity, store them in the Docker image
 mkdir -p lib
-cp ${HOME}/dependencies/fw8-flexbridge.tar.xz lib/
+cp "${HOME}/dependencies/fw8-flexbridge.tar.xz lib/"
 
 # TODO: Consider running a package restore here so that it's cached in the build image instead of having to run in the container each time
 # E.g., call download-dependencies-combined.sh at this point
 
 # The make-source shell script (and its common.sh helper) expects to live under ${HOME}/ci-builder-scripts/bash, so make sure that's the case
-mkdir -p ${HOME}/ci-builder-scripts/bash
-cp ${HOME}/packages/lfmerge/docker/common.sh ${HOME}/ci-builder-scripts/bash/
-cp ${HOME}/packages/lfmerge/docker/make-source ${HOME}/ci-builder-scripts/bash/
+mkdir -p "${HOME}/ci-builder-scripts/bash"
+cp "${HOME}/packages/lfmerge/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
+cp "${HOME}/packages/lfmerge/docker/make-source" "${HOME}/ci-builder-scripts/bash/"

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -9,6 +9,10 @@ mkdir -p "${HOME}/.gnupg" "${HOME}/ci-builder-scripts/bash" "${DEST}"
 REPO_ROOT="${1:-$(git rev-parse --show-toplevel)}"
 echo "Inside setup-workspace.sh, pwd is $(pwd) and repo root is ${REPO_ROOT}"
 
+echo 'DEBUG: ls -lR ${DEST}'
+ls -lR "${DEST}"
+echo 'DEBUG: ls -lR ${REPO_ROOT}'
+ls -lR "${REPO_ROOT}"
 sudo cp -a "${REPO_ROOT}" "${DEST}"
 sudo chown -R builder:users "${DEST}"
 echo 'DEBUG: ls -lR ${DEST}'


### PR DESCRIPTION
If running the workflow locally using `act` or `docker run`, we don't want any `git reset --hard HEAD` commands being run on the mounted repo, as that could easily blow away uncommitted work in the developer's own copy of the repo. So we mount the repo somewhere else, and then copy the repo into a working location that we can safely run `git reset` inside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/169)
<!-- Reviewable:end -->
