### PR TITLE
Make workflow safe to run locally (no git reset)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,7 +157,11 @@ jobs:
           AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
           AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/packages/lfmerge --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+
+      - name: Collect Debian images
+        if: steps.should_run.outcome == 'success'
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/finalresults ./
 
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ USER builder
 
 # Git repo should be mounted under ${HOME}/packages/lfmerge when run
 # E.g., `docker run --mount type=bind,source="$(pwd)",target=/home/builder/packages/lfmerge`
-RUN mkdir -p /home/builder/packages/lfmerge
-CMD /home/builder/packages/lfmerge/docker/scripts/build-and-test.sh ${DbVersion}
+RUN mkdir -p /home/builder/repo /home/builder/packages/lfmerge
+CMD /home/builder/repo/docker/scripts/build-and-test.sh ${DbVersion}
 # CMD doesn't actually run the script, it just gives `docker run` a default.
 # So it's okay for the Git repo to not be mounted yet.

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -6,12 +6,16 @@ export DbVersion="${1-7000072}"
 echo "Building for ${DbVersion}"
 sudo mkdir -p /usr/lib/lfmerge/${DbVersion}
 
-# Assumptions:
-# - Git repo is mounted under ${HOME}/packages/lfmerge
-# - Scripts live in ${HOME}/packages/lfmerge/docker/scripts
-cd /home/builder/packages/lfmerge
+# Assuming script is being run from inside the repo, find the repo root and use that as the working directory from now on
+echo "Script dir is ${SCRIPT_DIR}"
+cd "${SCRIPT_DIR}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+echo "Repo root is ${REPO_ROOT}"
+cd "${REPO_ROOT}"
 
-"$SCRIPT_DIR"/setup-workspace.sh ${DBVersion}
+"$SCRIPT_DIR"/setup-workspace.sh "${HOME}/packages/lfmerge"
+
+echo After setup-workspace.sh, pwd is $(pwd)
 
 "$SCRIPT_DIR"/gitversion-combined.sh ${DbVersion}
 

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -23,11 +23,8 @@ cd ${HOME}/packages/lfmerge
 mkdir -p finalresults
 rm -f finalresults/*
 rm -f lfmerge-*
-
 export MONO_PREFIX=/opt/mono5-sil
 RUNMODE="PACKAGEBUILD" BUILD=Release . environ
-
-cd -
 
 # for ((curDbVersion=7000068; curDbVersion<=7000070; curDbVersion++)); do
 	echo -e "\033[0;34mBuilding package for database version ${curDbVersion}\033[0m"


### PR DESCRIPTION
If running the workflow locally using `act` or `docker run`, we don't want any `git reset --hard HEAD` commands being run on the mounted repo, as that could easily blow away uncommitted work in the developer's own copy of the repo. So we mount the repo somewhere else, and then copy the repo into a working location that we can safely run `git reset` inside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/170)
<!-- Reviewable:end -->
