### PR TITLE
Fix local build with pbuild.sh script

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,7 +106,8 @@ jobs:
               ;;
 
             refs/heads/*)
-              PRERELEASE="~${REV##refs/heads/}.${BUILD_NUMBER}"
+              BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
+              PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
               ;;
 
             *)

--- a/docker/scripts/get-version-number.sh
+++ b/docker/scripts/get-version-number.sh
@@ -59,7 +59,8 @@
               ;;
 
             refs/heads/*)
-              PRERELEASE="~${REV##refs/heads/}.${BUILD_NUMBER}"
+              BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
+              PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
               ;;
 
             *)

--- a/docker/scripts/get-version-number.sh
+++ b/docker/scripts/get-version-number.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+          echo Start
+          REV=${GITHUB_REF:-$(git rev-parse --symbolic-full-name HEAD)}
+          DESCRIBE=$(git describe --long --match "v*")
+          MAJOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
+          MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
+          PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
+          # TODO: Detect need for minor/major updates and increment those instead of PATCH
+          COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
+          COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
+          if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
+            # If we're building from a tagged version, rebuild precisely that version
+            PATCH=$((${PATCH} + 1))
+          fi
+		  echo "Build number before: $BUILD_NUMBER"
+		  export BUILD_NUMBER=${BUILD_NUMBER:-${COMMIT_COUNT}}
+		  echo "Build number after: $BUILD_NUMBER"
+          export MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
+          export AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
+          export AssemblySemFileVer="${MajorMinorPatch}.0"
+          export InformationalVersion="${DESCRIBE}"
+          echo "Calculating name from ${REV}"
+          if [ -z ${REV} ]; then
+            echo Failed to get a meaningful commit name
+          fi
+          echo Got commit name ${REV}
+          RESULT=notfound
+          if echo "${REV}" | grep -E '^refs/pull/'; then
+            echo Found PR
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+          fi
+          if echo "${REV}" | grep -E '^refs/heads/'; then
+            echo Found branch
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/heads\///')
+          fi
+          if echo "${REV}" | grep -E '^refs/tags/'; then
+            echo Found tag
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/tags\///')
+          fi
+          echo Will calculate version from "${RESULT}" and "${MAJOR}.${MINOR}.${PATCH} with $COMMIT_COUNT commits since then, and current hash $COMMIT_HASH"
+
+          case "$REV" in
+            refs/heads/master | refs/heads/fieldworks8-master)
+              PRERELEASE="~alpha.${BUILD_NUMBER}"
+              ;;
+
+            refs/heads/qa | refs/heads/fieldworks8-qa)
+              PRERELEASE="~beta.${BUILD_NUMBER}"
+              ;;
+
+            refs/heads/live | refs/heads/fieldworks8-live)
+              PRERELEASE=
+              ;;
+
+            refs/pull/*)
+              PR_NUMBER=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+              PRERELEASE="~PR${PR_NUMBER}.${BUILD_NUMBER}"
+              ;;
+
+            refs/heads/*)
+              PRERELEASE="~${REV##refs/heads/}.${BUILD_NUMBER}"
+              ;;
+
+            *)
+              echo "Could not determine version number from ${REV}"
+              echo "::error ::Could not determine version number from ${REV}"
+              exit 1
+
+          esac
+          export DebPackageVersion=${MAJOR}.${MINOR}.${PATCH}${PRERELEASE}
+          export MsBuildVersion=$(echo "${DebPackageVersion}" | sed 's/~/-/')
+          echo "Will build package version ${DebPackageVersion}"
+          echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
+          echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
+          echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
+          echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
+          echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
+          echo "::set-output name=InformationalVersion::${InformationalVersion}"

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -17,6 +17,9 @@ cp "${DEST}/docker/common.sh" "${HOME}/ci-builder-scripts/bash/"
 cp "${DEST}/docker/make-source" "${HOME}/ci-builder-scripts/bash/"
 
 cd "${DEST}"
+if [ "${BRANCH_TO_BUILD}" ]; then
+	git checkout "${BRANCH_TO_BUILD}"
+fi
 git clean -dxf --exclude=packages/
 git reset --hard
 

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -78,5 +78,5 @@ EOF
 # Collect results
 for f in 68 69 70 72; do
 # for f in 72; do
-    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/repo/finalresults ./
+    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/packages/lfmerge/finalresults ./
 done

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -2,6 +2,44 @@
 
 which parallel >/dev/null || (echo 'Please run "sudo apt-get install parallel" and try again.'; exit 1)
 
+# Find appropriate branch(es) to build
+CURRENT_BRANCH="$(git name-rev --name-only HEAD)"
+PARENT_MAJOR_VERSION=$(git describe --long --match "v*" | cut -c1-2)
+
+# FW8 branches will have ancestors tagged v1.x, while FW9 branches will have ancestors tagged v2.x
+if [ "x$PARENT_MAJOR_VERSION" = "xv2" ]; then
+	IS_FW9=true
+else
+	IS_FW9=""
+fi
+
+if [ "${IS_FW9}" ]; then
+	echo Current branch is FW9, detecting FW8 branch to use...
+	FW9_BUILD_BRANCH="${CURRENT_BRANCH}"
+	if [ "$1" ]; then
+		FW8_BUILD_BRANCH="$1"
+	elif [ "${CURRENT_BRANCH}" = "master" -o "${CURRENT_BRANCH}" = "qa" -o "${CURRENT_BRANCH}" = "live" ]; then
+		FW8_BUILD_BRANCH="fieldworks8-${CURRENT_BRANCH}"
+	else
+		echo No FW 8 branch specified, assuming fieldworks8-master
+		echo To specify a different branch, run pbuild.sh '<'fw8-branch'>', e.g. '"'pbuild.sh feature/some-fw8-branch'"'
+		FW8_BUILD_BRANCH="fieldworks8-master"
+	fi
+else
+	echo Current branch is FW8, detecting FW9 branch to use...
+	FW8_BUILD_BRANCH="${CURRENT_BRANCH}"
+	if [ "$1" ]; then
+		FW9_BUILD_BRANCH="$1"
+	elif [ "${CURRENT_BRANCH}" = "fieldworks8-master" -o "${CURRENT_BRANCH}" = "fieldworks8-qa" -o "${CURRENT_BRANCH}" = "fieldworks8-live" ]; then
+		FW9_BUILD_BRANCH="${CURRENT_BRANCH##fieldworks8-}"
+	else
+		echo No FW 9 branch specified, assuming master
+		echo To specify a different branch, run pbuild.sh '<'fw8-branch'>', e.g. '"'pbuild.sh feature/some-fw8-branch'"'
+		FW9_BUILD_BRANCH="master"
+	fi
+fi
+echo Will build FW9 build from "${FW9_BUILD_BRANCH}" and FW8 builds from "${FW8_BUILD_BRANCH}"
+
 # Clean up any previous builds
 for f in 68 69 70 72; do
 # for f in 72; do
@@ -28,10 +66,10 @@ EOF
 
 # Run the build
 time parallel --no-notice <<EOF
-docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000068 lfmerge-build-7000068
-docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000069 lfmerge-build-7000069
-docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000070 lfmerge-build-7000070
-docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --mount type=bind,src=/storage/nuget,dst=/storage/nuget --name tmp-lfmerge-build-7000072 lfmerge-build-7000072
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BRANCH_TO_BUILD=${FW8_BUILD_BRANCH}" --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000068 lfmerge-build-7000068
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BRANCH_TO_BUILD=${FW8_BUILD_BRANCH}" --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000069 lfmerge-build-7000069
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BRANCH_TO_BUILD=${FW8_BUILD_BRANCH}" --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000070 lfmerge-build-7000070
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BRANCH_TO_BUILD=${FW9_BUILD_BRANCH}" --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --mount type=bind,src=/storage/nuget,dst=/storage/nuget --name tmp-lfmerge-build-7000072 lfmerge-build-7000072
 EOF
 
 # To run a single build instead, comment out the block above and uncomment the next line (and change 72 to 68/69/70 if needed)

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+which parallel >/dev/null || (echo 'Please run "sudo apt-get install parallel" and try again.'; exit 1)
+
+# Clean up any previous builds
+for f in 68 69 70 72; do
+# for f in 72; do
+    # Can safely ignore "container doesn't exist" as that's not an error
+    docker container rm tmp-lfmerge-build-70000${f} >/dev/null 2>/dev/null || true
+done
+
+# First create the base build container ONCE (not in parallel), to ensure that the slow steps (apt-get install mono5-sil) are cached
+docker build -t lfmerge-builder-base --target lfmerge-builder-base .
+
+# Create the build containers in series, because I've had trouble when creating them in parallel
+# (To create the build containers in series, which might be necessary if you have trouble with
+# Docker caching while creating them in parallel, just comment out the "time parallel" and "EOF" lines)
+time parallel --no-notice <<EOF
+docker build --build-arg DbVersion=7000068 -t lfmerge-build-7000068 .
+docker build --build-arg DbVersion=7000069 -t lfmerge-build-7000069 .
+docker build --build-arg DbVersion=7000070 -t lfmerge-build-7000070 .
+docker build --build-arg DbVersion=7000072 -t lfmerge-build-7000072 .
+EOF
+
+# To run a single build instead, comment out the block above and uncomment the next line (and change 72 to 68/69/70 if needed)
+# docker build --build-arg DbVersion=7000072 -t lfmerge-build-7000072 -f combined.dockerfile .
+. docker/scripts/get-version-number.sh
+
+# Run the build
+time parallel --no-notice <<EOF
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000068 lfmerge-build-7000068
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000069 lfmerge-build-7000069
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-7000070 lfmerge-build-7000070
+docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --mount type=tmpfs,dst=/tmp --env "BUILD_NUMBER=999" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --mount type=bind,src=/storage/nuget,dst=/storage/nuget --name tmp-lfmerge-build-7000072 lfmerge-build-7000072
+EOF
+
+# To run a single build instead, comment out the block above and uncomment the next line (and change 72 to 68/69/70 if needed)
+# docker run --mount type=bind,src=/storage/nuget,dst=/storage/nuget --name tmp-lfmerge-build-7000072 lfmerge-build-7000072
+
+# Collect results
+for f in 68 69 70 72; do
+# for f in 72; do
+    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/repo/finalresults ./
+done


### PR DESCRIPTION
This allows the pbuild.sh script to build correctly again, so that you can do local builds and get .deb packages without needing to create a PR, and without blowing away uncommitted work in your local Git repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/172)
<!-- Reviewable:end -->
