### PR TITLE
Speed up build by using gzip instead of xz

### DIFF
--- a/docker/make-source
+++ b/docker/make-source
@@ -123,13 +123,13 @@ if [ "$(cat debian/source/format)" == "3.0 (native)" ]; then
 	log "Native package. Building original source package."
 	# Unfortunately we have to list the files to ignore explicitly and can't use the default
 	# ignores because we want *.so files in the source package (needed for Mercurial)
-	TRACE dpkg-source --tar-ignore=*.a --tar-ignore=*.la --tar-ignore=*.o --tar-ignore=.*.sw? \
+	TRACE dpkg-source -Zgzip -z6 --tar-ignore=*.a --tar-ignore=*.la --tar-ignore=*.o --tar-ignore=.*.sw? \
 		--tar-ignore=*/*~ --tar-ignore=,,* --tar-ignore=.[#~]* --tar-ignore=.deps \
 		--tar-ignore=.git --tar-ignore=.gitattributes --tar-ignore=.gitignore \
 		--tar-ignore=.gitmodules --tar-ignore=.gitreview --tar-ignore=.hg --tar-ignore=.hgignore \
 		--tar-ignore=.hgsigs --tar-ignore=.hgtags --tar-ignore=.svn --tar-ignore=debian -b .
 
-	TRACE mv ../${source_package_name}_${latest_version_in_debian_changelog}.tar.xz ../${source_package_name}_${native_version}.orig.tar.xz
+	TRACE mv ../${source_package_name}_${latest_version_in_debian_changelog}.tar.gz ../${source_package_name}_${native_version}.orig.tar.gz
 	TRACE rm ../${source_package_name}_${latest_version_in_debian_changelog}.dsc
 	echo "3.0 (quilt)" > debian/source/format
 	debuild_opts="--source-option=--include-binaries --source-option=--tar-ignore"
@@ -140,7 +140,7 @@ if [ -z "$preserve_changelog_arg" -o -n "${package_version}" ]; then
 	dch $NEWPACKAGENAME --newversion "${native_version}-1" --force-bad-version --nomultimaint "$changelog_message"
 fi
 
-TRACE debuild -S -sa -Zxz -d ${signing_opt} ${debuild_opts}
+TRACE debuild -S -sa -Zgzip -z6 -d ${signing_opt} ${debuild_opts}
 
 log "Source package files exist with the following sha256sums:"
 if [ -z "$build_in_place" ]; then

--- a/docker/scripts/build-debpackages-combined.sh
+++ b/docker/scripts/build-debpackages-combined.sh
@@ -86,8 +86,6 @@ echo Should be a directory named "${SOURCE}-${PKGVERSION}"
 cd "${SOURCE}-${PKGVERSION}"
 # Build package, preserving env vars used in MsBuild packaging
 debuild -rfakeroot --preserve-envvar Version --preserve-envvar AssemblyVersion --preserve-envvar FileVersion --preserve-envvar InformationalVersion
-# Built packages are placed in parent directory, so move them into finalresults for artifact collection
-ls -l *deb || true
-ls -l ../*deb || true
-cp ../*deb . || true
-pwd
+# Built packages are placed in parent directory, so now we'll delete the unpacked directory so `docker container cp` doesn't collect it
+cd ..
+rm -rf "${SOURCE}-${PKGVERSION}"


### PR DESCRIPTION
Since we're not going to upload the source packages the build process creates, there's no sense in sacrificing time for better compression ratios. Instead, we'll use gzip at the default compression value (6), which is a lot faster and produces files that are 40% larger than what xz produces. We'll continue to use xz on the binary package files; it's just the orig.tar.xz (now orig.tar.gz) files where we want to use lower compression to save time because they're so large.

On my local machine, the build process for one .deb package went from taking 7:55 to taking 4:06. That's almost half the time. Well worth it for a 40% increase in the size of a file that will not be uploaded anywhere.

This is #176, against `fieldworks8-master` rather than `master`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/177)
<!-- Reviewable:end -->
