### PR TITLE
LfMerge build produces container instead of .deb files

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         if: matrix.dbversion < 7000072
         with:
-          ref: ${{ needs.calculate_branches.output.FW8Branch }}
+          ref: ${{ needs.calculate_branches.outputs.FW8Branch }}
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
 
       - name: Check out FW9 branch
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         if: matrix.dbversion >= 7000072
         with:
-          ref: ${{ needs.calculate_branches.output.FW9Branch }}
+          ref: ${{ needs.calculate_branches.outputs.FW9Branch }}
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
 
       - name: Verify current branch
@@ -68,8 +68,8 @@ jobs:
           echo FW8 was "${FW8Branch}"
           echo FW9 was "${FW9Branch}"
         env:
-          FW8Branch: ${{ needs.calculate_branches.output.FW8Branch }}
-          FW9Branch: ${{ needs.calculate_branches.output.FW9Branch }}
+          FW8Branch: ${{ needs.calculate_branches.outputs.FW8Branch }}
+          FW9Branch: ${{ needs.calculate_branches.outputs.FW9Branch }}
 
   #     - name: Calculate version number
   #       id: version

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -161,32 +161,57 @@ jobs:
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
-      - name: Collect Debian images
-      # Now should collect tarballs
-        if: steps.should_run.outcome == 'success'
-        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+    - name: Collect tarball images
+    # Now should collect tarballs
+      if: steps.should_run.outcome == 'success'
+      run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
-      - name: Build final Docker image
-        id: lfmerge_image
-        if: steps.should_run.outcome == 'success'
-        # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-        # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
-        with:
-          push: false
-          load: true
-          tags: sillsdev/lfmerge:${{ steps.version.outputs.MsBuildVersion }}
-          context: .
-          file: Dockerfile.finalresult
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
+    - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+      if: steps.should_run.outcome == 'success'
+      with:
+        name: lfmerge-tarball
+        path: tarball
 
-      - name: Show metadata from LfMerge image build step
-        run: echo "$METADATA"
-        env:
-          METADATA: ${{ steps.lfmerge_image.output.metadata }}
-        if: steps.should_run.outcome == 'success'
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
+    steps:
+    # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      with:
+        fetch-depth: 0
 
-      - name: List Docker images to verify build
-        if: steps.should_run.outcome == 'success'
-        run: docker image ls
+    - name: Download build artifacts
+      if: github.ref == 'refs/heads/live'
+      # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
+      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
+      with:
+        name: lfmerge-tarball
+        path: tarball
+
+    - name: Build final Docker image
+      id: lfmerge_image
+      if: steps.should_run.outcome == 'success'
+      # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
+      with:
+        push: false
+        load: true
+        tags: sillsdev/lfmerge:${{ steps.version.outputs.MsBuildVersion }}
+        context: .
+        file: Dockerfile.finalresult
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Show metadata from LfMerge image build step
+      run: echo "$METADATA"
+      env:
+        METADATA: ${{ steps.lfmerge_image.output.metadata }}
+      if: steps.should_run.outcome == 'success'
+
+    - name: List Docker images to verify build
+      if: steps.should_run.outcome == 'success'
+      run: docker image ls

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -184,7 +184,6 @@ jobs:
         fetch-depth: 0
 
     - name: Download build artifacts
-      if: github.ref == 'refs/heads/live'
       # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
       uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
       with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -211,8 +211,6 @@ jobs:
         tags: sillsdev/lfmerge:${{ steps.version.outputs.MsBuildVersion }}
         context: .
         file: Dockerfile.finalresult
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
       # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
 
     - name: Show metadata from LfMerge image build step

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,6 +139,7 @@ jobs:
           load: true
           tags: lfmerge-build-${{matrix.dbversion}}
           context: .
+          file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -161,59 +162,31 @@ jobs:
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
       - name: Collect Debian images
+      # Now should collect tarballs
         if: steps.should_run.outcome == 'success'
-        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/finalresults ./
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
-      # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
-      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+      - name: Build final Docker image
+        id: lfmerge_image
         if: steps.should_run.outcome == 'success'
+        # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
         with:
-          name: lfmerge-deb-files
-          path: finalresults/lfmerge*deb
+          push: false
+          load: true
+          tags: sillsdev/lfmerge:${{ steps.version.outputs.DebPackageVersion }}
+          context: .
+          file: Dockerfile.finalresult
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-    outputs:
-      MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+      - name: Show metadata from LfMerge image build step
+        run: echo "$METADATA"
+        env:
+          METADATA: ${{ steps.lfmerge_image.output.metadata }}
+        if: steps.should_run.outcome == 'success'
 
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
-    steps:
-    # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      with:
-        fetch-depth: 0
-
-    - name: Ensure release number exists
-      # Will throw an error, thereby cancelling the build, if MajorMinorPatch output was empty
-      env:
-        MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
-      run: test -n "${MajorMinorPatch}" && echo "Producing release ${MajorMinorPatch}"
-
-    - name: Tag new release
-      env:
-        MajorMinorPatch: ${{needs.build.outputs.MajorMinorPatch}}
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git tag -a -m "Release v${MajorMinorPatch}" "v${MajorMinorPatch}"
-        git push --tags
-
-    # On fieldworks8-live branch, we stop there and don't create a GitHub release
-
-    - name: Download build artifacts
-      if: github.ref == 'refs/heads/live'
-      # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      with:
-        name: lfmerge-deb-files
-        path: release
-
-    - name: Create GitHub release
-      if: github.ref == 'refs/heads/live'
-      # softprops/action-gh-release@v0.1.14 is commit 1e07f4398721186383de40550babbdf2b84acfc5
-      uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-      with:
-        tag_name: v${{needs.build.outputs.MajorMinorPatch}}
-        files: release/*.deb
-        generate_release_notes: true
+      - name: List Docker images to verify build
+        if: steps.should_run.outcome == 'success'
+        run: docker image ls

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -63,177 +63,183 @@ jobs:
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
 
       - name: Verify current branch
-        run: git branch --contains HEAD --format '%(refname)'
-
-      - name: Calculate version number
-        id: version
-        env:
-          BUILD_NUMBER: ${{ github.run_number }}
         run: |
-          echo Start
-          REV=${GITHUB_REF:-$(git rev-parse --symbolic-full-name HEAD)}
-          DESCRIBE=$(git describe --long --match "v*")
-          MAJOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
-          MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
-          PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
-          # TODO: Detect need for minor/major updates and increment those instead of PATCH
-          COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
-          COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
-          if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
-            # If we're building from a tagged version, rebuild precisely that version
-            PATCH=$((${PATCH} + 1))
-          fi
-          MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
-          AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
-          AssemblySemFileVer="${MajorMinorPatch}.0"
-          InformationalVersion="${DESCRIBE}"
-          echo "Calculating name from ${REV}"
-          if [ -z ${REV} ]; then
-            echo Failed to get a meaningful commit name
-          fi
-          echo Got commit name ${REV}
-          RESULT=notfound
-          if echo "${REV}" | grep -E '^refs/pull/'; then
-            echo Found PR
-            RESULT=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
-          fi
-          if echo "${REV}" | grep -E '^refs/heads/'; then
-            echo Found branch
-            RESULT=$(echo "${REV}" | sed -E 's/^refs\/heads\///')
-          fi
-          if echo "${REV}" | grep -E '^refs/tags/'; then
-            echo Found tag
-            RESULT=$(echo "${REV}" | sed -E 's/^refs\/tags\///')
-          fi
-          echo Will calculate version from "${RESULT}" and "${MAJOR}.${MINOR}.${PATCH} with $COMMIT_COUNT commits since then, and current hash $COMMIT_HASH"
-
-          case "$REV" in
-            refs/heads/master | refs/heads/fieldworks8-master)
-              PRERELEASE="~alpha.${BUILD_NUMBER}"
-              ;;
-
-            refs/heads/qa | refs/heads/fieldworks8-qa)
-              PRERELEASE="~beta.${BUILD_NUMBER}"
-              ;;
-
-            refs/heads/live | refs/heads/fieldworks8-live)
-              PRERELEASE=
-              ;;
-
-            refs/pull/*)
-              PR_NUMBER=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
-              PRERELEASE="~PR${PR_NUMBER}.${BUILD_NUMBER}"
-              ;;
-
-            refs/heads/*)
-              BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
-              PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
-              ;;
-
-            *)
-              echo "Could not determine version number from ${REV}"
-              echo "::error ::Could not determine version number from ${REV}"
-              exit 1
-
-          esac
-          DebPackageVersion=${MAJOR}.${MINOR}.${PATCH}${PRERELEASE}
-          MsBuildVersion=$(echo "${DebPackageVersion}" | sed 's/~/-/')
-          echo "Will build package version ${DebPackageVersion}"
-          echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
-          echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
-          echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
-          echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
-          echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
-          echo "::set-output name=InformationalVersion::${InformationalVersion}"
-
-      - name: Set up buildx for Docker
-        # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
-        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
-
-      - name: Build DBVersion-specific Docker image
-        # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-        with:
-          push: false
-          load: true
-          tags: lfmerge-build-${{matrix.dbversion}}
-          context: .
-          file: Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            DbVersion=${{matrix.dbversion}}
-
-      - name: Run docker image ls to verify build
-        run: docker image ls
-
-      - name: Run the build container
+          git branch --contains HEAD --format '%(refname)'
+          echo FW8 was "${FW8Branch}"
+          echo FW9 was "${FW9Branch}"
         env:
-          BUILD_NUMBER: ${{ github.run_number }}
-          DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
-          MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
-          MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
-          AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
-          AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
-          InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+          FW8Branch: ${{ needs.calculate_branches.output.FW8Branch }}
+          FW9Branch: ${{ needs.calculate_branches.output.FW9Branch }}
 
-      - name: Collect tarball images
-      # Now should collect tarballs
-        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+  #     - name: Calculate version number
+  #       id: version
+  #       env:
+  #         BUILD_NUMBER: ${{ github.run_number }}
+  #       run: |
+  #         echo Start
+  #         REV=${GITHUB_REF:-$(git rev-parse --symbolic-full-name HEAD)}
+  #         DESCRIBE=$(git describe --long --match "v*")
+  #         MAJOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
+  #         MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
+  #         PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
+  #         # TODO: Detect need for minor/major updates and increment those instead of PATCH
+  #         COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
+  #         COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
+  #         if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
+  #           # If we're building from a tagged version, rebuild precisely that version
+  #           PATCH=$((${PATCH} + 1))
+  #         fi
+  #         MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
+  #         AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
+  #         AssemblySemFileVer="${MajorMinorPatch}.0"
+  #         InformationalVersion="${DESCRIBE}"
+  #         echo "Calculating name from ${REV}"
+  #         if [ -z ${REV} ]; then
+  #           echo Failed to get a meaningful commit name
+  #         fi
+  #         echo Got commit name ${REV}
+  #         RESULT=notfound
+  #         if echo "${REV}" | grep -E '^refs/pull/'; then
+  #           echo Found PR
+  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+  #         fi
+  #         if echo "${REV}" | grep -E '^refs/heads/'; then
+  #           echo Found branch
+  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/heads\///')
+  #         fi
+  #         if echo "${REV}" | grep -E '^refs/tags/'; then
+  #           echo Found tag
+  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/tags\///')
+  #         fi
+  #         echo Will calculate version from "${RESULT}" and "${MAJOR}.${MINOR}.${PATCH} with $COMMIT_COUNT commits since then, and current hash $COMMIT_HASH"
 
-      # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
-      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
-        with:
-          name: lfmerge-tarball
-          path: tarball
-    outputs:
-      MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
-      MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+  #         case "$REV" in
+  #           refs/heads/master | refs/heads/fieldworks8-master)
+  #             PRERELEASE="~alpha.${BUILD_NUMBER}"
+  #             ;;
 
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
-    steps:
-    # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      with:
-        fetch-depth: 0
+  #           refs/heads/qa | refs/heads/fieldworks8-qa)
+  #             PRERELEASE="~beta.${BUILD_NUMBER}"
+  #             ;;
 
-    - name: Download build artifacts
-      # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      with:
-        name: lfmerge-tarball
-        path: tarball
+  #           refs/heads/live | refs/heads/fieldworks8-live)
+  #             PRERELEASE=
+  #             ;;
 
-    - name: Ensure all parts of final tarball exist
-      # TODO: Should no longer be needed; verify, then remove
-      run: |
-        mkdir -p tarball/lfmerge-7000068 || true
-        mkdir -p tarball/lfmerge-7000069 || true
-        mkdir -p tarball/lfmerge-7000070 || true
-        mkdir -p tarball/lfmerge-7000072 || true
-        mkdir -p tarball/lfmerge || true
+  #           refs/pull/*)
+  #             PR_NUMBER=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+  #             PRERELEASE="~PR${PR_NUMBER}.${BUILD_NUMBER}"
+  #             ;;
 
-    - name: Build final Docker image
-      id: lfmerge_image
-      # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-      # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
-      with:
-        push: false
-        load: true
-        tags: sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }}
-        context: .
-        file: Dockerfile.finalresult
-      # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
+  #           refs/heads/*)
+  #             BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
+  #             PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
+  #             ;;
 
-    - name: Show metadata from LfMerge image build step
-      run: echo "$METADATA"
-      env:
-        METADATA: ${{ steps.lfmerge_image.output.metadata }}
+  #           *)
+  #             echo "Could not determine version number from ${REV}"
+  #             echo "::error ::Could not determine version number from ${REV}"
+  #             exit 1
 
-    - name: List Docker images to verify build
-      run: docker image ls
+  #         esac
+  #         DebPackageVersion=${MAJOR}.${MINOR}.${PATCH}${PRERELEASE}
+  #         MsBuildVersion=$(echo "${DebPackageVersion}" | sed 's/~/-/')
+  #         echo "Will build package version ${DebPackageVersion}"
+  #         echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
+  #         echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
+  #         echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
+  #         echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
+  #         echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
+  #         echo "::set-output name=InformationalVersion::${InformationalVersion}"
+
+  #     - name: Set up buildx for Docker
+  #       # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
+  #       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+
+  #     - name: Build DBVersion-specific Docker image
+  #       # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+  #       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+  #       with:
+  #         push: false
+  #         load: true
+  #         tags: lfmerge-build-${{matrix.dbversion}}
+  #         context: .
+  #         file: Dockerfile
+  #         cache-from: type=gha
+  #         cache-to: type=gha,mode=max
+  #         build-args: |
+  #           DbVersion=${{matrix.dbversion}}
+
+  #     - name: Run docker image ls to verify build
+  #       run: docker image ls
+
+  #     - name: Run the build container
+  #       env:
+  #         BUILD_NUMBER: ${{ github.run_number }}
+  #         DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
+  #         MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+  #         MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+  #         AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
+  #         AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
+  #         InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
+  #       run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+
+  #     - name: Collect tarball images
+  #     # Now should collect tarballs
+  #       run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+
+  #     # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
+  #     - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+  #       with:
+  #         name: lfmerge-tarball
+  #         path: tarball
+  #   outputs:
+  #     MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+  #     MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+
+  # release:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
+  #   steps:
+  #   # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
+  #   - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+  #     with:
+  #       fetch-depth: 0
+
+  #   - name: Download build artifacts
+  #     # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
+  #     uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
+  #     with:
+  #       name: lfmerge-tarball
+  #       path: tarball
+
+  #   - name: Ensure all parts of final tarball exist
+  #     # TODO: Should no longer be needed; verify, then remove
+  #     run: |
+  #       mkdir -p tarball/lfmerge-7000068 || true
+  #       mkdir -p tarball/lfmerge-7000069 || true
+  #       mkdir -p tarball/lfmerge-7000070 || true
+  #       mkdir -p tarball/lfmerge-7000072 || true
+  #       mkdir -p tarball/lfmerge || true
+
+  #   - name: Build final Docker image
+  #     id: lfmerge_image
+  #     # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+  #     uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+  #     # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
+  #     with:
+  #       push: false
+  #       load: true
+  #       tags: sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }}
+  #       context: .
+  #       file: Dockerfile.finalresult
+  #     # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
+
+  #   - name: Show metadata from LfMerge image build step
+  #     run: echo "$METADATA"
+  #     env:
+  #       METADATA: ${{ steps.lfmerge_image.output.metadata }}
+
+  #   - name: List Docker images to verify build
+  #     run: docker image ls

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           push: false
           load: true
-          tags: sillsdev/lfmerge:${{ steps.version.outputs.DebPackageVersion }}
+          tags: sillsdev/lfmerge:${{ steps.version.outputs.MsBuildVersion }}
           context: .
           file: Dockerfile.finalresult
           cache-from: type=gha

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Calculate branches to build
         run: |
+          echo "${GITHUB_REF}"
           ./calculate-branches.sh | grep FW.Branch >> "${GITHUB_ENV}"
 
       - name: Save branch names in output

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,8 +10,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  calculate_branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current branch
+        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          fetch-depth: 0  # All history for all tags and branches, since branch calculation step needs that
+
+      - name: Calculate branches to build
+        run: |
+          ./calculate-branches.sh | grep FW.Branch >> "${GITHUB_ENV}"
+
+      - name: Save branch names in output
+        id: branches_to_build
+        run: |
+          echo "FW8Branch=${FW8Branch}"
+          echo "FW9Branch=${FW9Branch}"
+          echo "::set-output name=FW8Branch::${FW8Branch}"
+          echo "::set-output name=FW9Branch::${FW9Branch}"
+
+    outputs:
+      FW8Branch: ${{ steps.branches_to_build.outputs.FW8Branch }}
+      FW9Branch: ${{ steps.branches_to_build.outputs.FW9Branch }}
+
   build:
     runs-on: ubuntu-latest
+    needs: calculate_branches
 
     # As of 2021-11-24, we build LfMerge for LCM DB versions 68-72 (and there is no 71)
     strategy:
@@ -20,33 +46,27 @@ jobs:
         distro: [ 'bionic' ]
 
     steps:
-      - name: Decide if this build configuration should run
-        id: should_run
-        run: true
-        if: ${{ (github.event_name == 'push' && !startsWith(github.ref_name, 'fieldworks8-')) || (github.event_name == 'push' && startsWith(github.ref_name, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion < 7000072) || (github.event_name == 'pull_request' && !startsWith(github.base_ref, 'fieldworks8-') && matrix.dbversion >= 7000072) }}
-
-      - name: Check out current branch
-        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-        if: steps.should_run.outcome == 'success'
-        with:
-          fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
-
       - name: Check out FW8 branch
         # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-        if: github.event_name == 'push' && !startsWith(github.ref_name, 'fieldworks8-') && matrix.dbversion < 7000072 && steps.should_run.outcome == 'success'
+        if: matrix.dbversion < 7000072
         with:
-          ref: fieldworks8-${{ github.ref_name }}
+          ref: ${{ needs.calculate_branches.output.FW8Branch }}
+          fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
+
+      - name: Check out FW9 branch
+        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        if: matrix.dbversion >= 7000072
+        with:
+          ref: ${{ needs.calculate_branches.output.FW9Branch }}
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
 
       - name: Verify current branch
         run: git branch --contains HEAD --format '%(refname)'
-        if: steps.should_run.outcome == 'success'
 
       - name: Calculate version number
         id: version
-        if: steps.should_run.outcome == 'success'
         env:
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
@@ -131,7 +151,6 @@ jobs:
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
 
       - name: Build DBVersion-specific Docker image
-        if: steps.should_run.outcome == 'success'
         # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
         with:
@@ -146,11 +165,9 @@ jobs:
             DbVersion=${{matrix.dbversion}}
 
       - name: Run docker image ls to verify build
-        if: steps.should_run.outcome == 'success'
         run: docker image ls
 
       - name: Run the build container
-        if: steps.should_run.outcome == 'success'
         env:
           BUILD_NUMBER: ${{ github.run_number }}
           DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
@@ -163,12 +180,10 @@ jobs:
 
       - name: Collect tarball images
       # Now should collect tarballs
-        if: steps.should_run.outcome == 'success'
         run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
       # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
       - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
-        if: steps.should_run.outcome == 'success'
         with:
           name: lfmerge-tarball
           path: tarball
@@ -194,7 +209,7 @@ jobs:
         path: tarball
 
     - name: Ensure all parts of final tarball exist
-      # Mostly used for PR builds where lfmerge-7000068 might not exist in an FW9 build, etc.
+      # TODO: Should no longer be needed; verify, then remove
       run: |
         mkdir -p tarball/lfmerge-7000068 || true
         mkdir -p tarball/lfmerge-7000069 || true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,175 +72,175 @@ jobs:
           FW8Branch: ${{ needs.calculate_branches.outputs.FW8Branch }}
           FW9Branch: ${{ needs.calculate_branches.outputs.FW9Branch }}
 
-  #     - name: Calculate version number
-  #       id: version
-  #       env:
-  #         BUILD_NUMBER: ${{ github.run_number }}
-  #       run: |
-  #         echo Start
-  #         REV=${GITHUB_REF:-$(git rev-parse --symbolic-full-name HEAD)}
-  #         DESCRIBE=$(git describe --long --match "v*")
-  #         MAJOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
-  #         MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
-  #         PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
-  #         # TODO: Detect need for minor/major updates and increment those instead of PATCH
-  #         COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
-  #         COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
-  #         if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
-  #           # If we're building from a tagged version, rebuild precisely that version
-  #           PATCH=$((${PATCH} + 1))
-  #         fi
-  #         MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
-  #         AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
-  #         AssemblySemFileVer="${MajorMinorPatch}.0"
-  #         InformationalVersion="${DESCRIBE}"
-  #         echo "Calculating name from ${REV}"
-  #         if [ -z ${REV} ]; then
-  #           echo Failed to get a meaningful commit name
-  #         fi
-  #         echo Got commit name ${REV}
-  #         RESULT=notfound
-  #         if echo "${REV}" | grep -E '^refs/pull/'; then
-  #           echo Found PR
-  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
-  #         fi
-  #         if echo "${REV}" | grep -E '^refs/heads/'; then
-  #           echo Found branch
-  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/heads\///')
-  #         fi
-  #         if echo "${REV}" | grep -E '^refs/tags/'; then
-  #           echo Found tag
-  #           RESULT=$(echo "${REV}" | sed -E 's/^refs\/tags\///')
-  #         fi
-  #         echo Will calculate version from "${RESULT}" and "${MAJOR}.${MINOR}.${PATCH} with $COMMIT_COUNT commits since then, and current hash $COMMIT_HASH"
+      - name: Calculate version number
+        id: version
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          echo Start
+          REV=${GITHUB_REF:-$(git rev-parse --symbolic-full-name HEAD)}
+          DESCRIBE=$(git describe --long --match "v*")
+          MAJOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\1/')
+          MINOR=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\2/')
+          PATCH=$(echo "$DESCRIBE" | sed -E 's/^v([0-9]+)\.([0-9]+)\.([0-9]+).*$/\3/')
+          # TODO: Detect need for minor/major updates and increment those instead of PATCH
+          COMMIT_COUNT=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-([^-]+)-.*$/\1/')
+          COMMIT_HASH=$(echo "$DESCRIBE" | sed -E 's/^[^-]+-[^-]+-g(.*)$/\1/')
+          if [ -n "$COMMIT_COUNT" -a "$COMMIT_COUNT" -gt 0 ]; then
+            # If we're building from a tagged version, rebuild precisely that version
+            PATCH=$((${PATCH} + 1))
+          fi
+          MajorMinorPatch="${MAJOR}.${MINOR}.${PATCH}"
+          AssemblySemVer="${MajorMinorPatch}.${BUILD_NUMBER}"
+          AssemblySemFileVer="${MajorMinorPatch}.0"
+          InformationalVersion="${DESCRIBE}"
+          echo "Calculating name from ${REV}"
+          if [ -z ${REV} ]; then
+            echo Failed to get a meaningful commit name
+          fi
+          echo Got commit name ${REV}
+          RESULT=notfound
+          if echo "${REV}" | grep -E '^refs/pull/'; then
+            echo Found PR
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+          fi
+          if echo "${REV}" | grep -E '^refs/heads/'; then
+            echo Found branch
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/heads\///')
+          fi
+          if echo "${REV}" | grep -E '^refs/tags/'; then
+            echo Found tag
+            RESULT=$(echo "${REV}" | sed -E 's/^refs\/tags\///')
+          fi
+          echo Will calculate version from "${RESULT}" and "${MAJOR}.${MINOR}.${PATCH} with $COMMIT_COUNT commits since then, and current hash $COMMIT_HASH"
 
-  #         case "$REV" in
-  #           refs/heads/master | refs/heads/fieldworks8-master)
-  #             PRERELEASE="~alpha.${BUILD_NUMBER}"
-  #             ;;
+          case "$REV" in
+            refs/heads/master | refs/heads/fieldworks8-master)
+              PRERELEASE="~alpha.${BUILD_NUMBER}"
+              ;;
 
-  #           refs/heads/qa | refs/heads/fieldworks8-qa)
-  #             PRERELEASE="~beta.${BUILD_NUMBER}"
-  #             ;;
+            refs/heads/qa | refs/heads/fieldworks8-qa)
+              PRERELEASE="~beta.${BUILD_NUMBER}"
+              ;;
 
-  #           refs/heads/live | refs/heads/fieldworks8-live)
-  #             PRERELEASE=
-  #             ;;
+            refs/heads/live | refs/heads/fieldworks8-live)
+              PRERELEASE=
+              ;;
 
-  #           refs/pull/*)
-  #             PR_NUMBER=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
-  #             PRERELEASE="~PR${PR_NUMBER}.${BUILD_NUMBER}"
-  #             ;;
+            refs/pull/*)
+              PR_NUMBER=$(echo "${REV}" | sed -E 's/^refs\/pull\/([0-9]+)\/merge/\1/')
+              PRERELEASE="~PR${PR_NUMBER}.${BUILD_NUMBER}"
+              ;;
 
-  #           refs/heads/*)
-  #             BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
-  #             PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
-  #             ;;
+            refs/heads/*)
+              BRANCH=$(echo "${REV##refs/heads/}" | sed 's/\//-/')
+              PRERELEASE="~${BRANCH}.${BUILD_NUMBER}"
+              ;;
 
-  #           *)
-  #             echo "Could not determine version number from ${REV}"
-  #             echo "::error ::Could not determine version number from ${REV}"
-  #             exit 1
+            *)
+              echo "Could not determine version number from ${REV}"
+              echo "::error ::Could not determine version number from ${REV}"
+              exit 1
 
-  #         esac
-  #         DebPackageVersion=${MAJOR}.${MINOR}.${PATCH}${PRERELEASE}
-  #         MsBuildVersion=$(echo "${DebPackageVersion}" | sed 's/~/-/')
-  #         echo "Will build package version ${DebPackageVersion}"
-  #         echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
-  #         echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
-  #         echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
-  #         echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
-  #         echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
-  #         echo "::set-output name=InformationalVersion::${InformationalVersion}"
+          esac
+          DebPackageVersion=${MAJOR}.${MINOR}.${PATCH}${PRERELEASE}
+          MsBuildVersion=$(echo "${DebPackageVersion}" | sed 's/~/-/')
+          echo "Will build package version ${DebPackageVersion}"
+          echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
+          echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
+          echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
+          echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
+          echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
+          echo "::set-output name=InformationalVersion::${InformationalVersion}"
 
-  #     - name: Set up buildx for Docker
-  #       # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
-  #       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+      - name: Set up buildx for Docker
+        # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
 
-  #     - name: Build DBVersion-specific Docker image
-  #       # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-  #       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-  #       with:
-  #         push: false
-  #         load: true
-  #         tags: lfmerge-build-${{matrix.dbversion}}
-  #         context: .
-  #         file: Dockerfile
-  #         cache-from: type=gha
-  #         cache-to: type=gha,mode=max
-  #         build-args: |
-  #           DbVersion=${{matrix.dbversion}}
+      - name: Build DBVersion-specific Docker image
+        # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+        with:
+          push: false
+          load: true
+          tags: lfmerge-build-${{matrix.dbversion}}
+          context: .
+          file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            DbVersion=${{matrix.dbversion}}
 
-  #     - name: Run docker image ls to verify build
-  #       run: docker image ls
+      - name: Run docker image ls to verify build
+        run: docker image ls
 
-  #     - name: Run the build container
-  #       env:
-  #         BUILD_NUMBER: ${{ github.run_number }}
-  #         DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
-  #         MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
-  #         MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
-  #         AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
-  #         AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
-  #         InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
-  #       run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
+      - name: Run the build container
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+          DebPackageVersion: ${{ steps.version.outputs.DebPackageVersion }}
+          MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+          MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+          AssemblySemVer: ${{ steps.version.outputs.AssemblySemVer }}
+          AssemblySemFileVer: ${{ steps.version.outputs.AssemblySemFileVer }}
+          InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
+        run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
-  #     - name: Collect tarball images
-  #     # Now should collect tarballs
-  #       run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+      - name: Collect tarball images
+      # Now should collect tarballs
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
-  #     # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
-  #     - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
-  #       with:
-  #         name: lfmerge-tarball
-  #         path: tarball
-  #   outputs:
-  #     MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
-  #     MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+      # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
+      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+        with:
+          name: lfmerge-tarball
+          path: tarball
+    outputs:
+      MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+      MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
 
-  # release:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
-  #   steps:
-  #   # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-  #   - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-  #     with:
-  #       fetch-depth: 0
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
+    steps:
+    # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      with:
+        fetch-depth: 0
 
-  #   - name: Download build artifacts
-  #     # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
-  #     uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
-  #     with:
-  #       name: lfmerge-tarball
-  #       path: tarball
+    - name: Download build artifacts
+      # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
+      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
+      with:
+        name: lfmerge-tarball
+        path: tarball
 
-  #   - name: Ensure all parts of final tarball exist
-  #     # TODO: Should no longer be needed; verify, then remove
-  #     run: |
-  #       mkdir -p tarball/lfmerge-7000068 || true
-  #       mkdir -p tarball/lfmerge-7000069 || true
-  #       mkdir -p tarball/lfmerge-7000070 || true
-  #       mkdir -p tarball/lfmerge-7000072 || true
-  #       mkdir -p tarball/lfmerge || true
+    - name: Ensure all parts of final tarball exist
+      # TODO: Should no longer be needed; verify, then remove
+      run: |
+        mkdir -p tarball/lfmerge-7000068 || true
+        mkdir -p tarball/lfmerge-7000069 || true
+        mkdir -p tarball/lfmerge-7000070 || true
+        mkdir -p tarball/lfmerge-7000072 || true
+        mkdir -p tarball/lfmerge || true
 
-  #   - name: Build final Docker image
-  #     id: lfmerge_image
-  #     # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-  #     uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-  #     # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
-  #     with:
-  #       push: false
-  #       load: true
-  #       tags: sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }}
-  #       context: .
-  #       file: Dockerfile.finalresult
-  #     # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
+    - name: Build final Docker image
+      id: lfmerge_image
+      # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+      # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
+      with:
+        push: false
+        load: true
+        tags: sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }}
+        context: .
+        file: Dockerfile.finalresult
+      # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
 
-  #   - name: Show metadata from LfMerge image build step
-  #     run: echo "$METADATA"
-  #     env:
-  #       METADATA: ${{ steps.lfmerge_image.output.metadata }}
+    - name: Show metadata from LfMerge image build step
+      run: echo "$METADATA"
+      env:
+        METADATA: ${{ steps.lfmerge_image.output.metadata }}
 
-  #   - name: List Docker images to verify build
-  #     run: docker image ls
+    - name: List Docker images to verify build
+      run: docker image ls

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -176,7 +176,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
+    # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
     steps:
     # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
@@ -202,7 +202,6 @@ jobs:
 
     - name: Build final Docker image
       id: lfmerge_image
-      if: steps.should_run.outcome == 'success'
       # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
       # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
@@ -214,13 +213,12 @@ jobs:
         file: Dockerfile.finalresult
         cache-from: type=gha
         cache-to: type=gha,mode=max
+      # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')
 
     - name: Show metadata from LfMerge image build step
       run: echo "$METADATA"
       env:
         METADATA: ${{ steps.lfmerge_image.output.metadata }}
-      if: steps.should_run.outcome == 'success'
 
     - name: List Docker images to verify build
-      if: steps.should_run.outcome == 'success'
       run: docker image ls

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -191,6 +191,15 @@ jobs:
         name: lfmerge-tarball
         path: tarball
 
+    - name: Ensure all parts of final tarball exist
+      # Mostly used for PR builds where lfmerge-7000068 might not exist in an FW9 build, etc.
+      run: |
+        mkdir -p tarball/lfmerge-7000068 || true
+        mkdir -p tarball/lfmerge-7000069 || true
+        mkdir -p tarball/lfmerge-7000070 || true
+        mkdir -p tarball/lfmerge-7000072 || true
+        mkdir -p tarball/lfmerge || true
+
     - name: Build final Docker image
       id: lfmerge_image
       if: steps.should_run.outcome == 'success'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -161,17 +161,17 @@ jobs:
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
-    - name: Collect tarball images
-    # Now should collect tarballs
-      if: steps.should_run.outcome == 'success'
-      run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+      - name: Collect tarball images
+      # Now should collect tarballs
+        if: steps.should_run.outcome == 'success'
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
-    # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
-    - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
-      if: steps.should_run.outcome == 'success'
-      with:
-        name: lfmerge-tarball
-        path: tarball
+      # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
+      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+        if: steps.should_run.outcome == 'success'
+        with:
+          name: lfmerge-tarball
+          path: tarball
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out current branch
-        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0  # All history for all tags and branches, since branch calculation step needs that
 
@@ -48,16 +47,14 @@ jobs:
 
     steps:
       - name: Check out FW8 branch
-        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@v2.4.0
         if: matrix.dbversion < 7000072
         with:
           ref: ${{ needs.calculate_branches.outputs.FW8Branch }}
           fetch-depth: 0  # All history for all tags and branches, since GitVersion needs that
 
       - name: Check out FW9 branch
-        # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@v2.4.0
         if: matrix.dbversion >= 7000072
         with:
           ref: ${{ needs.calculate_branches.outputs.FW9Branch }}
@@ -165,7 +162,6 @@ jobs:
           load: true
           tags: lfmerge-build-${{matrix.dbversion}}
           context: .
-          file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -189,8 +185,7 @@ jobs:
       # Now should collect tarballs
         run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
 
-      # actions/upload-artifact@v2.2.4 is commit 27121b0bdffd731efa15d66772be8dc71245d074
-      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+      - uses: actions/upload-artifact@v2.2.4
         with:
           name: lfmerge-tarball
           path: tarball
@@ -201,16 +196,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    # if: github.event_name == 'push' && (github.ref == 'refs/heads/live' || github.ref == 'refs/heads/fieldworks8-live')
+
     steps:
-    # actions/checkout@v2.0.10 is commit ec3a7ce113134d7a93b817d10a8272cb61118579
-    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/checkout@v2.4.0
       with:
         fetch-depth: 0
 
     - name: Download build artifacts
-      # actions/download-artifact@v2.0.10 is commit 3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
+      uses: actions/download-artifact@v2.0.10
       with:
         name: lfmerge-tarball
         path: tarball

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -172,6 +172,9 @@ jobs:
         with:
           name: lfmerge-tarball
           path: tarball
+    outputs:
+      MajorMinorPatch: ${{ steps.version.outputs.MajorMinorPatch }}
+      MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
 
   release:
     runs-on: ubuntu-latest
@@ -207,7 +210,7 @@ jobs:
       with:
         push: false
         load: true
-        tags: sillsdev/lfmerge:${{ steps.version.outputs.MsBuildVersion }}
+        tags: sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }}
         context: .
         file: Dockerfile.finalresult
       # TODO: Set push to equal the value of (github.event_name == 'push' && github.ref == 'refs/heads/live')

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /et
 RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
 
 # # Build as a non-root user
-RUN useradd -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
+RUN useradd -u 1001 -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
 	chown -R builder:users /build
 

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -29,7 +29,7 @@ FROM lfmerge-base AS lfmerge
 # python - required by Mercurial, which is bundled in the LFMerge installation
 # rsyslog - lfmerge logs to rsyslog and expects this to exist
 # rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
-# logrotate - TODO: is this required?
+# logrotate - ensure logs won't grow without bound, and that old logs get cleaned up automatically
 # iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
 # less - so we can read syslog during manual debugging of issues
 # vim-tiny - so we can edit state files (to change HOLD to IDLE) during manual debugging of issues

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -50,6 +50,7 @@ RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue && ch
 
 # TODO: Turn this into environment variables, because we want to be able to just set env vars in k8s config and restart the container
 COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
+COPY mercurial-cacerts.rc /etc/mercurial/hgrc.d/cacerts.rc
 COPY lfmergeqm-background.sh /
 COPY lfmergeqm-looping.sh /
 COPY entrypoint.sh /

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -46,6 +46,8 @@ ADD tarball/lfmerge/ /
 
 RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue && chown -R www-data:www-data /var/lib/languageforge
 
+# TODO: Turn this into environment variables, because we want to be able to just set env vars in k8s config and restart the container
+COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
 COPY lfmergeqm-background.sh /
 COPY lfmergeqm-looping.sh /
 COPY entrypoint.sh /

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:experimental
+ARG DbVersion=7000072
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-builder-base
+WORKDIR /build/lfmerge
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+RUN apt-get update && apt-get install -y gnupg
+
+COPY docker/sil-packages-key.gpg .
+COPY docker/sil-packages-testing-key.gpg .
+RUN apt-key add sil-packages-key.gpg
+RUN apt-key add sil-packages-testing-key.gpg
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
+# Dependencies from Debian "control" file
+RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
+
+# # Build as a non-root user
+RUN useradd -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
+    echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
+	chown -R builder:users /build
+
+FROM lfmerge-builder-base AS lfmerge
+
+ADD tarball/lfmerge-7000068/ /
+ADD tarball/lfmerge-7000069/ /
+ADD tarball/lfmerge-7000070/ /
+ADD tarball/lfmerge-7000072/ /
+# Add more lines here if we add new DbVersions
+
+ADD tarball/lfmerge/ /

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 ARG DbVersion=7000072
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-builder-base
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-base
 WORKDIR /build/lfmerge
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,12 +17,24 @@ RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /et
 # Dependencies from Debian "control" file
 RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
 
-# # Build as a non-root user
-RUN useradd -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
-    echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
-	chown -R builder:users /build
+# Ensure fieldworks group exists in case lfmerge-fdo package didn't install it, and that www-data is part of that group
+# Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists
+RUN addgroup --system --quiet fieldworks ; \
+    adduser --quiet www-data fieldworks ; \
+	install -d -o www-data -g www-data -m 02775 /var/www/.local
 
-FROM lfmerge-builder-base AS lfmerge
+FROM lfmerge-base AS lfmerge
+
+# install LFMerge prerequisites
+# python - required by Mercurial, which is bundled in the LFMerge installation
+# rsyslog - lfmerge logs to rsyslog and expects this to exist
+# logrotate - TODO: is this required?
+# iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
+RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
+&& echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
+&& apt-get update \
+&& apt-get install --yes --no-install-recommends python rsyslog logrotate iputils-ping inotify-tools \
+&& rm -rf /var/lib/apt/lists/*
 
 ADD tarball/lfmerge-7000068/ /
 ADD tarball/lfmerge-7000069/ /
@@ -31,3 +43,13 @@ ADD tarball/lfmerge-7000072/ /
 # Add more lines here if we add new DbVersions
 
 ADD tarball/lfmerge/ /
+
+RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue && chown -R www-data:www-data /var/lib/languageforge
+
+COPY lfmergeqm-background.sh /
+COPY lfmergeqm-looping.sh /
+COPY entrypoint.sh /
+RUN chmod +x /lfmergeqm-background.sh /lfmergeqm-looping.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/lfmergeqm-looping.sh" ]

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -31,10 +31,12 @@ FROM lfmerge-base AS lfmerge
 # rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
 # logrotate - TODO: is this required?
 # iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
+# less - so we can read syslog during manual debugging of issues
+# vim-tiny - so we can edit state files (to change HOLD to IDLE) during manual debugging of issues
 RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
 && echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
 && apt-get update \
-&& apt-get install --yes --no-install-recommends python rsyslog logrotate iputils-ping inotify-tools \
+&& apt-get install --yes --no-install-recommends python rsyslog logrotate iputils-ping inotify-tools less vim-tiny \
 && rm -rf /var/lib/apt/lists/* \
 && sed -i '/load="imklog"/s/^/#/' /etc/rsyslog.conf
 
@@ -50,7 +52,7 @@ RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue && ch
 
 # TODO: Turn this into environment variables, because we want to be able to just set env vars in k8s config and restart the container
 COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
-COPY mercurial-cacerts.rc /etc/mercurial/hgrc.d/cacerts.rc
+COPY mercurial-cacerts.rc /etc/mercurial/hgrc
 COPY lfmergeqm-background.sh /
 COPY lfmergeqm-looping.sh /
 COPY entrypoint.sh /

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -28,13 +28,15 @@ FROM lfmerge-base AS lfmerge
 # install LFMerge prerequisites
 # python - required by Mercurial, which is bundled in the LFMerge installation
 # rsyslog - lfmerge logs to rsyslog and expects this to exist
+# rsyslog customizations (imklog reads kernel messages, which isn't allowed or desired in Docker containers)
 # logrotate - TODO: is this required?
 # iputils-ping - Chorus (part of LFMerge) requires the "ping" command to be available on the command line
 RUN curl -L http://linux.lsdev.sil.org/downloads/sil-testing.gpg | apt-key add - \
 && echo "deb http://linux.lsdev.sil.org/ubuntu bionic main" > /etc/apt/sources.list.d/linux-lsdev-sil-org.list \
 && apt-get update \
 && apt-get install --yes --no-install-recommends python rsyslog logrotate iputils-ping inotify-tools \
-&& rm -rf /var/lib/apt/lists/*
+&& rm -rf /var/lib/apt/lists/* \
+&& sed -i '/load="imklog"/s/^/#/' /etc/rsyslog.conf
 
 ADD tarball/lfmerge-7000068/ /
 ADD tarball/lfmerge-7000069/ /

--- a/calculate-branches.sh
+++ b/calculate-branches.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Find appropriate branch(es) to build
-CURRENT_BRANCH=$(git name-rev --name-only HEAD | sed -e 's/^remotes\///')
+CURRENT_BRANCH=${GITHUB_REF:-$(git name-rev --name-only HEAD)}
 PARENT_MAJOR_VERSION=$(git describe --long --match "v*" | cut -c1-2)
 
 # FW8 branches will have ancestors tagged v1.x, while FW9 branches will have ancestors tagged v2.x

--- a/calculate-branches.sh
+++ b/calculate-branches.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Find appropriate branch(es) to build
-CURRENT_BRANCH="$(git name-rev --name-only HEAD)"
+CURRENT_BRANCH=$(git name-rev --name-only HEAD | sed -e 's/^remotes\///')
 PARENT_MAJOR_VERSION=$(git describe --long --match "v*" | cut -c1-2)
 
 # FW8 branches will have ancestors tagged v1.x, while FW9 branches will have ancestors tagged v2.x

--- a/calculate-branches.sh
+++ b/calculate-branches.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Find appropriate branch(es) to build
+CURRENT_BRANCH="$(git name-rev --name-only HEAD)"
+PARENT_MAJOR_VERSION=$(git describe --long --match "v*" | cut -c1-2)
+
+# FW8 branches will have ancestors tagged v1.x, while FW9 branches will have ancestors tagged v2.x
+if [ "x$PARENT_MAJOR_VERSION" = "xv2" ]; then
+	IS_FW9=true
+else
+	IS_FW9=""
+fi
+
+if [ "${IS_FW9}" ]; then
+	FW9_BUILD_BRANCH="${CURRENT_BRANCH}"
+	if [ "$1" ]; then
+		FW8_BUILD_BRANCH="$1"
+	elif [ "${CURRENT_BRANCH}" = "master" -o "${CURRENT_BRANCH}" = "qa" -o "${CURRENT_BRANCH}" = "live" ]; then
+		FW8_BUILD_BRANCH="fieldworks8-${CURRENT_BRANCH}"
+	else
+		FW8_BUILD_BRANCH="fieldworks8-master"
+	fi
+else
+	FW8_BUILD_BRANCH="${CURRENT_BRANCH}"
+	if [ "$1" ]; then
+		FW9_BUILD_BRANCH="$1"
+	elif [ "${CURRENT_BRANCH}" = "fieldworks8-master" -o "${CURRENT_BRANCH}" = "fieldworks8-qa" -o "${CURRENT_BRANCH}" = "fieldworks8-live" ]; then
+		FW9_BUILD_BRANCH="${CURRENT_BRANCH##fieldworks8-}"
+	else
+		FW9_BUILD_BRANCH="master"
+	fi
+fi
+
+echo FW8Branch="${FW8_BUILD_BRANCH}"
+echo FW9Branch="${FW9_BUILD_BRANCH}"

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -6,11 +6,14 @@ export DbVersion="${1-7000072}"
 echo "Building for ${DbVersion}"
 sudo mkdir -p /usr/lib/lfmerge/${DbVersion}
 
+echo Running as $(id)
 # Assuming script is being run from inside the repo, find the repo root and use that as the working directory from now on
 echo "Script dir is ${SCRIPT_DIR}"
+ls -ld "${SCRIPT_DIR}"
 cd "${SCRIPT_DIR}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 echo "Repo root is ${REPO_ROOT}"
+ls -ld "${REPO_ROOT}"
 cd "${REPO_ROOT}"
 
 "$SCRIPT_DIR"/setup-workspace.sh "${HOME}/packages/lfmerge"

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -29,4 +29,6 @@ fi
 
 rm -rf "$SCRIPT_DIR"/data/php   # So it doesn't get into the .deb source package
 
-"$SCRIPT_DIR"/build-debpackages-combined.sh ${DbVersion}
+# "$SCRIPT_DIR"/build-debpackages-combined.sh ${DbVersion}
+
+"$SCRIPT_DIR"/create-installation-tarball.sh ${DbVersion}

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -33,55 +33,55 @@ fixutf8=/$(LIB)/MercurialExtensions/fixutf8/fixutf8.py
 endef
 EOF
 
-	# Install binaries
-	install -d $(DBDESTDIR)/$(LIB)
-	install -m 644 output/$(BUILD)/$(FRAMEWORK)/*.* $(DBDESTDIR)/$(LIB)
-	install -m 755 output/$(BUILD)/$(FRAMEWORK)/chorusmerge $(DBDESTDIR)/$(LIB)
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
-	install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
-	install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions
-	install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
-	install -m 755 Mercurial/hg $(DBDESTDIR)/$(LIB)/Mercurial
-	install -m 644 Mercurial/mercurial.ini $(DBDESTDIR)/$(LIB)/Mercurial
-	install -m 644 Mercurial/hgext/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext
-	install -m 644 Mercurial/hgext/convert/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
-	install -m 644 Mercurial/hgext/highlight/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
-	install -m 644 Mercurial/hgext/largefiles/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
-	install -m 644 Mercurial/hgext/zeroconf/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
-	install -m 644 Mercurial/mercurial/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
-	install -m 644 Mercurial/mercurial/hgweb/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
-	install -m 644 Mercurial/mercurial/httpclient/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
-	install -m 644 MercurialExtensions/fixutf8/*.* $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
-	# Apparently the downloaded mercurial.ini doesn't have the right fixutf8 config, and it also
-	# has wrong line endings, so we re-create the entire file
-	echo "$$MERCURIAL_INI" > $(DBDESTDIR)/$(LIB)/Mercurial/mercurial.ini
-	# Remove unit test related files
-	cd $(DBDESTDIR)/$(LIB) && \
-		rm -f *.Tests.dll* *.Tests.pdb* *.TestApp.exe* SIL.TestUtilities.dll* \
-			SIL.TestUtilities.pdb* nunit.framework.dll *Moq.dll
-	# Install environ file
-	install -d $(DBDESTDIR)/$(SHARE)
-	install -m 644 environ $(DBDESTDIR)/$(SHARE)
-	# Install wrapper scripts
-	install -d $(COMMONDESTDIR)/usr/bin
-	install -m 755 lfmerge $(COMMONDESTDIR)/usr/bin
-	install -m 755 lfmergeqm $(COMMONDESTDIR)/usr/bin
-	install -m 755 startlfmerge $(DBDESTDIR)/$(LIB)
-	# Install conf file
-	install -d $(COMMONDESTDIR)/etc/languageforge/conf
-	install -m 644 debian/sendreceive.conf $(COMMONDESTDIR)/etc/languageforge/conf
-	# Create working directories
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/state
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/webwork
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/mergequeue
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/commitqueue
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/receivequeue
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/sendqueue
-	mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/Templates
+# Install binaries
+install -d $(DBDESTDIR)/$(LIB)
+install -m 644 output/$(BUILD)/$(FRAMEWORK)/*.* $(DBDESTDIR)/$(LIB)
+install -m 755 output/$(BUILD)/$(FRAMEWORK)/chorusmerge $(DBDESTDIR)/$(LIB)
+install -d $(DBDESTDIR)/$(LIB)/Mercurial
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
+install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
+install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions
+install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
+install -m 755 Mercurial/hg $(DBDESTDIR)/$(LIB)/Mercurial
+install -m 644 Mercurial/mercurial.ini $(DBDESTDIR)/$(LIB)/Mercurial
+install -m 644 Mercurial/hgext/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext
+install -m 644 Mercurial/hgext/convert/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
+install -m 644 Mercurial/hgext/highlight/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
+install -m 644 Mercurial/hgext/largefiles/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
+install -m 644 Mercurial/hgext/zeroconf/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
+install -m 644 Mercurial/mercurial/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
+install -m 644 Mercurial/mercurial/hgweb/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
+install -m 644 Mercurial/mercurial/httpclient/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
+install -m 644 MercurialExtensions/fixutf8/*.* $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
+# Apparently the downloaded mercurial.ini doesn't have the right fixutf8 config, and it also
+# has wrong line endings, so we re-create the entire file
+echo "$$MERCURIAL_INI" > $(DBDESTDIR)/$(LIB)/Mercurial/mercurial.ini
+# Remove unit test related files
+cd $(DBDESTDIR)/$(LIB) && \
+	rm -f *.Tests.dll* *.Tests.pdb* *.TestApp.exe* SIL.TestUtilities.dll* \
+		SIL.TestUtilities.pdb* nunit.framework.dll *Moq.dll
+# Install environ file
+install -d $(DBDESTDIR)/$(SHARE)
+install -m 644 environ $(DBDESTDIR)/$(SHARE)
+# Install wrapper scripts
+install -d $(COMMONDESTDIR)/usr/bin
+install -m 755 lfmerge $(COMMONDESTDIR)/usr/bin
+install -m 755 lfmergeqm $(COMMONDESTDIR)/usr/bin
+install -m 755 startlfmerge $(DBDESTDIR)/$(LIB)
+# Install conf file
+install -d $(COMMONDESTDIR)/etc/languageforge/conf
+install -m 644 debian/sendreceive.conf $(COMMONDESTDIR)/etc/languageforge/conf
+# Create working directories
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/state
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/webwork
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/mergequeue
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/commitqueue
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/receivequeue
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/sendqueue
+mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/Templates

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -12,9 +12,6 @@ export FRAMEWORK=net462
 
 export DatabaseVersion=${1:-7000072}
 
-echo ${DatabaseVersion}
-exit 1
-
 # Model version dependent DESTDIR
 DBDESTDIR		= debian/lfmerge-${DatabaseVersion}
 # Common DESTDIR

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -79,12 +79,3 @@ mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/commitqueue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/receivequeue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/sendqueue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/Templates
-
-# Create tarball
-cd ${COMMONDESTDIR}/..
-BASEPATH=$(pwd)
-DEBPATH=$(realpath "${DBDESTDIR}" --relative-to "${BASEPATH}")
-COMMONPATH=$(realpath "${COMMONDESTDIR}" --relative-to "${BASEPATH}")
-tar cf - "${DEBPATH}" | gzip -c > "${DEBPATH}.tar.gz"
-tar cf - "${COMMONPATH}" | gzip -c > "${COMMONPATH}.tar.gz"
-ls -l "${DEBPATH}.tar.gz" "${COMMONPATH}.tar.gz"

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -29,59 +29,59 @@ cat >MERCURIAL_INI <<EOF
 eol=
 hgext.graphlog=
 convert=
-fixutf8=/$(LIB)/MercurialExtensions/fixutf8/fixutf8.py
+fixutf8=/${LIB}/MercurialExtensions/fixutf8/fixutf8.py
 endef
 EOF
 
 # Install binaries
-install -d $(DBDESTDIR)/$(LIB)
-install -m 644 output/$(BUILD)/$(FRAMEWORK)/*.* $(DBDESTDIR)/$(LIB)
-install -m 755 output/$(BUILD)/$(FRAMEWORK)/chorusmerge $(DBDESTDIR)/$(LIB)
-install -d $(DBDESTDIR)/$(LIB)/Mercurial
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
-install -d $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
-install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions
-install -d $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
-install -m 755 Mercurial/hg $(DBDESTDIR)/$(LIB)/Mercurial
-install -m 644 Mercurial/mercurial.ini $(DBDESTDIR)/$(LIB)/Mercurial
-install -m 644 Mercurial/hgext/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext
-install -m 644 Mercurial/hgext/convert/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/convert
-install -m 644 Mercurial/hgext/highlight/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/highlight
-install -m 644 Mercurial/hgext/largefiles/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/largefiles
-install -m 644 Mercurial/hgext/zeroconf/*.* $(DBDESTDIR)/$(LIB)/Mercurial/hgext/zeroconf
-install -m 644 Mercurial/mercurial/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial
-install -m 644 Mercurial/mercurial/hgweb/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/hgweb
-install -m 644 Mercurial/mercurial/httpclient/*.* $(DBDESTDIR)/$(LIB)/Mercurial/mercurial/httpclient
-install -m 644 MercurialExtensions/fixutf8/*.* $(DBDESTDIR)/$(LIB)/MercurialExtensions/fixutf8
+install -d ${DBDESTDIR}/${LIB}
+install -m 644 output/${BUILD}/${FRAMEWORK}/*.* ${DBDESTDIR}/${LIB}
+install -m 755 output/${BUILD}/${FRAMEWORK}/chorusmerge ${DBDESTDIR}/${LIB}
+install -d ${DBDESTDIR}/${LIB}/Mercurial
+install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext
+install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/convert
+install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/highlight
+install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/largefiles
+install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/zeroconf
+install -d ${DBDESTDIR}/${LIB}/Mercurial/mercurial
+install -d ${DBDESTDIR}/${LIB}/Mercurial/mercurial/hgweb
+install -d ${DBDESTDIR}/${LIB}/Mercurial/mercurial/httpclient
+install -d ${DBDESTDIR}/${LIB}/MercurialExtensions
+install -d ${DBDESTDIR}/${LIB}/MercurialExtensions/fixutf8
+install -m 755 Mercurial/hg ${DBDESTDIR}/${LIB}/Mercurial
+install -m 644 Mercurial/mercurial.ini ${DBDESTDIR}/${LIB}/Mercurial
+install -m 644 Mercurial/hgext/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgext
+install -m 644 Mercurial/hgext/convert/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgext/convert
+install -m 644 Mercurial/hgext/highlight/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgext/highlight
+install -m 644 Mercurial/hgext/largefiles/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgext/largefiles
+install -m 644 Mercurial/hgext/zeroconf/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgext/zeroconf
+install -m 644 Mercurial/mercurial/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial
+install -m 644 Mercurial/mercurial/hgweb/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial/hgweb
+install -m 644 Mercurial/mercurial/httpclient/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial/httpclient
+install -m 644 MercurialExtensions/fixutf8/*.* ${DBDESTDIR}/${LIB}/MercurialExtensions/fixutf8
 # Apparently the downloaded mercurial.ini doesn't have the right fixutf8 config, and it also
 # has wrong line endings, so we re-create the entire file
-echo "$$MERCURIAL_INI" > $(DBDESTDIR)/$(LIB)/Mercurial/mercurial.ini
+echo "$$MERCURIAL_INI" > ${DBDESTDIR}/${LIB}/Mercurial/mercurial.ini
 # Remove unit test related files
-cd $(DBDESTDIR)/$(LIB) && \
+cd ${DBDESTDIR}/${LIB} && \
 	rm -f *.Tests.dll* *.Tests.pdb* *.TestApp.exe* SIL.TestUtilities.dll* \
 		SIL.TestUtilities.pdb* nunit.framework.dll *Moq.dll
 # Install environ file
-install -d $(DBDESTDIR)/$(SHARE)
-install -m 644 environ $(DBDESTDIR)/$(SHARE)
+install -d ${DBDESTDIR}/${SHARE}
+install -m 644 environ ${DBDESTDIR}/${SHARE}
 # Install wrapper scripts
-install -d $(COMMONDESTDIR)/usr/bin
-install -m 755 lfmerge $(COMMONDESTDIR)/usr/bin
-install -m 755 lfmergeqm $(COMMONDESTDIR)/usr/bin
-install -m 755 startlfmerge $(DBDESTDIR)/$(LIB)
+install -d ${COMMONDESTDIR}/usr/bin
+install -m 755 lfmerge ${COMMONDESTDIR}/usr/bin
+install -m 755 lfmergeqm ${COMMONDESTDIR}/usr/bin
+install -m 755 startlfmerge ${DBDESTDIR}/${LIB}
 # Install conf file
-install -d $(COMMONDESTDIR)/etc/languageforge/conf
-install -m 644 debian/sendreceive.conf $(COMMONDESTDIR)/etc/languageforge/conf
+install -d ${COMMONDESTDIR}/etc/languageforge/conf
+install -m 644 debian/sendreceive.conf ${COMMONDESTDIR}/etc/languageforge/conf
 # Create working directories
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/state
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/webwork
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/mergequeue
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/commitqueue
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/receivequeue
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/sendqueue
-mkdir -p $(COMMONDESTDIR)/var/lib/languageforge/lexicon/sendreceive/Templates
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/state
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/webwork
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/mergequeue
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/commitqueue
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/receivequeue
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/sendqueue
+mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/Templates

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -27,7 +27,6 @@ eol=
 hgext.graphlog=
 convert=
 fixutf8=/${LIB}/MercurialExtensions/fixutf8/fixutf8.py
-endef
 EOF
 
 # Install binaries

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -6,18 +6,16 @@
 export HOME=/tmp
 export XDG_CONFIG_HOME=/tmp/.config
 export BUILD=Release
-export MONO_PREFIX=/opt/mono5-sil
-export MSBUILD=msbuild
 export FRAMEWORK=net462
 
 export DatabaseVersion=${1:-7000072}
 
 # Model version dependent DESTDIR
-DBDESTDIR		= debian/lfmerge-${DatabaseVersion}
+export DBDESTDIR=tarball/lfmerge-${DatabaseVersion}
 # Common DESTDIR
-COMMONDESTDIR	= debian/lfmerge
-LIB				= usr/lib/lfmerge/${DatabaseVersion}
-SHARE			= usr/share/lfmerge/${DatabaseVersion}
+export COMMONDESTDIR=tarball/lfmerge
+export LIB=usr/lib/lfmerge/${DatabaseVersion}
+export SHARE=usr/share/lfmerge/${DatabaseVersion}
 
 export DBVERSIONPATH=/usr/lib/lfmerge/${DatabaseVersion}
 
@@ -59,9 +57,9 @@ install -m 644 Mercurial/mercurial/hgweb/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercu
 install -m 644 Mercurial/mercurial/httpclient/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial/httpclient
 install -m 644 MercurialExtensions/fixutf8/*.* ${DBDESTDIR}/${LIB}/MercurialExtensions/fixutf8
 # Remove unit test related files
-cd ${DBDESTDIR}/${LIB} && \
+(cd ${DBDESTDIR}/${LIB} && \
 	rm -f *.Tests.dll* *.Tests.pdb* *.TestApp.exe* SIL.TestUtilities.dll* \
-		SIL.TestUtilities.pdb* nunit.framework.dll *Moq.dll
+		SIL.TestUtilities.pdb* nunit.framework.dll *Moq.dll)
 # Install environ file
 install -d ${DBDESTDIR}/${SHARE}
 install -m 644 environ ${DBDESTDIR}/${SHARE}
@@ -81,3 +79,12 @@ mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/commitqueue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/receivequeue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/sendqueue
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/Templates
+
+# Create tarball
+cd ${COMMONDESTDIR}/..
+BASEPATH=$(pwd)
+DEBPATH=$(realpath "${DBDESTDIR}" --relative-to "${BASEPATH}")
+COMMONPATH=$(realpath "${COMMONDESTDIR}" --relative-to "${BASEPATH}")
+tar cf - "${DEBPATH}" | gzip -c > "${DEBPATH}.tar.gz"
+tar cf - "${COMMONPATH}" | gzip -c > "${COMMONPATH}.tar.gz"
+ls -l "${DEBPATH}.tar.gz" "${COMMONPATH}.tar.gz"

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -21,7 +21,9 @@ SHARE			= usr/share/lfmerge/${DatabaseVersion}
 
 export DBVERSIONPATH=/usr/lib/lfmerge/${DatabaseVersion}
 
-cat >MERCURIAL_INI <<EOF
+# Apparently the downloaded mercurial.ini doesn't have the right fixutf8 config, and it also
+# has wrong line endings, so we re-create the entire file
+cat >Mercurial/mercurial.ini <<EOF
 [extensions]
 eol=
 hgext.graphlog=
@@ -56,9 +58,6 @@ install -m 644 Mercurial/mercurial/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial
 install -m 644 Mercurial/mercurial/hgweb/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial/hgweb
 install -m 644 Mercurial/mercurial/httpclient/*.* ${DBDESTDIR}/${LIB}/Mercurial/mercurial/httpclient
 install -m 644 MercurialExtensions/fixutf8/*.* ${DBDESTDIR}/${LIB}/MercurialExtensions/fixutf8
-# Apparently the downloaded mercurial.ini doesn't have the right fixutf8 config, and it also
-# has wrong line endings, so we re-create the entire file
-echo "$$MERCURIAL_INI" > ${DBDESTDIR}/${LIB}/Mercurial/mercurial.ini
 # Remove unit test related files
 cd ${DBDESTDIR}/${LIB} && \
 	rm -f *.Tests.dll* *.Tests.pdb* *.TestApp.exe* SIL.TestUtilities.dll* \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# rsyslog needs to run so that lfmerge can log to /var/log/syslog
+/etc/init.d/rsyslog start
+
+# Ensure /var/log/syslog exists so tail -f /var/log/syslog will run
+logger "Starting container..."
+# echo /var/log/syslog to container stdout so it shows up in `kubectl logs`
+tail -f /var/log/syslog &
+
+# run lfmergeqm on startup to clear out any failed send/receive sessions from previous container
+/lfmergeqm-background.sh & # MUST be run as a background process as it kicks off an infinite loop to run every 24 hours
+
+CMD=${1:-"/lfmergeqm-looping.sh"}
+
+[ -x "$CMD" ] && exec "$CMD" || exec /bin/bash

--- a/lfmerge.conf
+++ b/lfmerge.conf
@@ -1,0 +1,10 @@
+# Configuration file for LfMerge
+BaseDir = /var/lib/languageforge/lexicon/sendreceive
+WebworkDir = webwork
+TemplatesDir = Templates
+MongoHostname = db
+MongoPort = 27017
+MongoMainDatabaseName = scriptureforge
+MongoDatabaseNamePrefix = sf_
+VerboseProgress = true
+PhpSourcePath = /var/www/html

--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Run lfmergeqm every 24 hours to clean up any failed syncs that aren't in the queue
+# This script MUST be run as a background process ("script.sh &")!
+
+# First time we're run is before Apache starts up, so wait 60 seconds to allow Apache time to start up
+# (because LfMerge depends on Apache and PHP being up so that the RunClass.php code will work right)
+sleep 60
+
+# Now enter an infinite loop that will run eery 24*60*60 = 86400 seconds
+while :
+do
+  which lfmergeqm && su www-data -s /bin/bash -c lfmergeqm
+  sleep 86400
+done

--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -3,11 +3,6 @@
 # Run lfmergeqm every 24 hours to clean up any failed syncs that aren't in the queue
 # This script MUST be run as a background process ("script.sh &")!
 
-# First time we're run is before Apache starts up, so wait 60 seconds to allow Apache time to start up
-# (because LfMerge depends on Apache and PHP being up so that the RunClass.php code will work right)
-sleep 60
-
-# Now enter an infinite loop that will run eery 24*60*60 = 86400 seconds
 while :
 do
   sudo -u www-data lfmergeqm

--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -10,6 +10,6 @@ sleep 60
 # Now enter an infinite loop that will run eery 24*60*60 = 86400 seconds
 while :
 do
-  which lfmergeqm && su www-data -s /bin/bash -c lfmergeqm
+  sudo -u www-data lfmergeqm
   sleep 86400
 done

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Run lfmergeqm every time a file is created in the sync queue
+
+# This is expected to run as the CMD, launched by the entry point.
+
+while inotifywait -e create /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
+  su www-data -s /bin/bash -c lfmergeqm
+done

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -5,5 +5,5 @@
 # This is expected to run as the CMD, launched by the entry point.
 
 while inotifywait -e create /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
-  su www-data -s /bin/bash -c lfmergeqm
+  sudo -u www-data lfmergeqm
 done

--- a/mercurial-cacerts.rc
+++ b/mercurial-cacerts.rc
@@ -1,0 +1,4 @@
+[web]
+# user can disable this Debian default by overriding this option in ~/.hgrc
+# and/or using the --insecure command line switch
+cacerts = /etc/ssl/certs/ca-certificates.crt

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -44,6 +44,7 @@ echo Will build FW9 build from "${FW9_BUILD_BRANCH}" and FW8 builds from "${FW8_
 for f in 68 69 70 72; do
 # for f in 72; do
     # Can safely ignore "container doesn't exist" as that's not an error
+    docker container kill tmp-lfmerge-build-70000${f} >/dev/null 2>/dev/null || true
     docker container rm tmp-lfmerge-build-70000${f} >/dev/null 2>/dev/null || true
 done
 

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -79,7 +79,8 @@ EOF
 # docker run --mount type=bind,src=/storage/nuget,dst=/storage/nuget --name tmp-lfmerge-build-7000072 lfmerge-build-7000072
 
 # Collect results
+mkdir -p tarball
 for f in 68 69 70 72; do
 # for f in 72; do
-    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/packages/lfmerge/finalresults ./
+    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/repo/tarball ./
 done


### PR DESCRIPTION
Closes #185.

The basic way this works is that the `debian/rules` file (a Makefile that has to have specifically-named targets for the Debian build process to process it) is converted to a shell script. It puts the compilation results into place in a `tarball` directory, which is then copied into a new Docker image.

Roadmap for this PR before I mark it ready for review:

* [x] Test the built lfmerge container locally
* [x] Edit GHA workflow to push the built container to Docker Hub

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/186)
<!-- Reviewable:end -->
