### PR TITLE
Allow pbuild.sh and GHA workflow to both run

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -154,6 +154,10 @@ jobs:
         # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
 
+      - name: Find current UID
+        id: uid
+        run: echo "::set-output name=uid::$(id -u)"
+
       - name: Build DBVersion-specific Docker image
         # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
@@ -166,6 +170,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             DbVersion=${{matrix.dbversion}}
+            BUILDER_UID=${{steps.uid.outputs.uid}}
 
       - name: Run docker image ls to verify build
         run: docker image ls

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,13 @@ RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /et
 # Dependencies from Debian "control" file
 RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
 
+ENV DEFAULT_BUILDER_UID=1000
+ARG BUILDER_UID
+RUN test -n "$BUILDER_UID"
+ENV BUILDER_UID="$BUILDER_UID"
+
 # # Build as a non-root user
-RUN useradd -u 1001 -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
+RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -G www-data,fieldworks,systemd-journal -m -s /bin/bash builder ; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
 	chown -R builder:users /build
 

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -48,16 +48,18 @@ for f in 68 69 70 72; do
     docker container rm tmp-lfmerge-build-70000${f} >/dev/null 2>/dev/null || true
 done
 
+CURRENT_UID=$(id -u)
+
 # First create the base build container ONCE (not in parallel), to ensure that the slow steps (apt-get install mono5-sil) are cached
-docker build -t lfmerge-builder-base --target lfmerge-builder-base .
+docker build --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-builder-base --target lfmerge-builder-base .
 
 # Create the build images for each DbVersion in parallel
 # NOTE: now that the differences are only ENV lines, parallel no longer gains any time. Should we turn this into a for loop?
 time parallel --no-notice <<EOF
-docker build --build-arg DbVersion=7000068 -t lfmerge-build-7000068 .
-docker build --build-arg DbVersion=7000069 -t lfmerge-build-7000069 .
-docker build --build-arg DbVersion=7000070 -t lfmerge-build-7000070 .
-docker build --build-arg DbVersion=7000072 -t lfmerge-build-7000072 .
+docker build --build-arg DbVersion=7000068 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000068 .
+docker build --build-arg DbVersion=7000069 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000069 .
+docker build --build-arg DbVersion=7000070 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000070 .
+docker build --build-arg DbVersion=7000072 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000072 .
 EOF
 
 # To run a single build instead, comment out the block above and uncomment the next line (and change 72 to 68/69/70 if needed)


### PR DESCRIPTION
This should create the `builder` user with an appropriate uid in both the pbuild.sh and GHA workflow environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/191)
<!-- Reviewable:end -->
