### PR TITLE
Docker build action cannot have both push and load

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -237,7 +237,6 @@ jobs:
       # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
       with:
         push: ${{(github.event_name == 'push' && github.ref == 'refs/heads/live')}}
-        load: true
         tags: ghcr.io/sillsdev/lfmerge:${{ needs.build.outputs.MsBuildVersion }},ghcr.io/sillsdev/lfmerge:latest
         context: .
         file: Dockerfile.finalresult


### PR DESCRIPTION
The `push` and `load` flags are mutually exclusive. `load` puts the built image in the local Docker image inventory, to be used in a later step. `push` pushes it to a registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/196)
<!-- Reviewable:end -->
