### PR TITLE
Get settings from environment variables

### DIFF
--- a/LfMerge.TestApp/TestAppMainClass.cs
+++ b/LfMerge.TestApp/TestAppMainClass.cs
@@ -18,14 +18,11 @@ namespace LfMerge.TestApp
 				return;
 
 			var folder = Path.Combine(Path.GetTempPath(), "LfMerge.TestApp");
-			LfMergeSettings.ConfigDir = folder;
+			System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir, folder);
 
 			MainClass.Container = MainClass.RegisterTypes().Build();
 			var settings = MainClass.Container.Resolve<LfMergeSettings>();
-			var config = new IniData();
-			var main = config.Global;
-			main["BaseDir"] = folder;
-			settings.Initialize(config);
+			settings.Initialize();
 
 			var queueDir = settings.GetQueueDirectory(QueueNames.Synchronize);
 			Directory.CreateDirectory(queueDir);

--- a/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
+++ b/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
@@ -17,13 +17,12 @@ namespace LfMerge.Core.Tests
 			public void Initialize(string basePath, string webworkDir = null,
 				string templateDir = null)
 			{
-				var replacementConfig = new IniData(ParsedConfig);
-				replacementConfig.Global["BaseDir"] = basePath;
+				System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir, basePath);
 				if (!string.IsNullOrEmpty(webworkDir))
-					replacementConfig.Global["WebworkDir"] = webworkDir;
+					System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir, webworkDir);
 				if (!string.IsNullOrEmpty(templateDir))
-					replacementConfig.Global["TemplatesDir"] = templateDir;
-				Initialize(replacementConfig);
+					System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir, templateDir);
+				base.Initialize();
 			}
 		}
 

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -81,29 +81,12 @@ namespace LfMerge.Core.Tests
 
 	public class LfMergeSettingsDouble: LfMergeSettings
 	{
-		static LfMergeSettingsDouble()
-		{
-			ConfigDir = Path.GetRandomFileName();
-		}
-
 		public LfMergeSettingsDouble(string replacementBaseDir)
 		{
-			var replacementConfig = new IniData(ParsedConfig);
-			replacementConfig.Global["BaseDir"] = replacementBaseDir;
-			Initialize(replacementConfig);
+			System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir, replacementBaseDir);
+			System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_VerboseProgress, "true");
+			base.Initialize();
 			CommitWhenDone = false;
-			VerboseProgress = true;
-			PhpSourcePath = Path.Combine(TestEnvironment.FindGitRepoRoot(), "data", "php", "src");
-		}
-
-		public override IniData ParseFiles(string defaultConfig, string globalConfigFilename)
-		{
-			// Hide the console warning about "no global configuration file found" because we're doing that on purpose
-			var savedStdout = Console.Out;
-			Console.SetOut(TextWriter.Null);
-			IniData result = base.ParseFiles(defaultConfig, globalConfigFilename);
-			Console.SetOut(savedStdout);
-			return result;
 		}
 	}
 

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -11,6 +11,16 @@ namespace LfMerge.Core
 			MinimalModelVersion = 7000068;
 		}
 
+		public const string SettingsEnvVar_BaseDir = "LFMERGE_BASE_DIR";
+		public const string SettingsEnvVar_WebworkDir = "LFMERGE_WEBWORK_DIR";
+		public const string SettingsEnvVar_TemplatesDir = "LFMERGE_TEMPLATES_DIR";
+		public const string SettingsEnvVar_MongoHostname = "LFMERGE_MONGO_HOSTNAME";
+		public const string SettingsEnvVar_MongoPort = "LFMERGE_MONGO_PORT";
+		public const string SettingsEnvVar_MongoMainDatabaseName = "LFMERGE_MONGO_MAIN_DB_NAME";
+		public const string SettingsEnvVar_MongoDatabaseNamePrefix = "LFMERGE_MONGO_DB_NAME_PREFIX";
+		public const string SettingsEnvVar_VerboseProgress = "LFMERGE_VERBOSE_PROGRESS";
+		public const string SettingsEnvVar_LanguageDepotRepoUri = "LFMERGE_LANGUAGE_DEPOT_REPO_URI";
+
 		public static Dictionary<string, string> LcmOptionlistNames = new Dictionary<string, string>()
 		{
 			// Option lists that are currently used in LF (as of 2016-03-01)

--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -65,7 +65,7 @@ namespace LfMerge.Core
 		}
 
 		public static int StartLfMerge(string projectCode, ActionNames action,
-			string modelVersion, bool allowFreshClone, string configDir = null)
+			string modelVersion, bool allowFreshClone)
 		{
 			if (string.IsNullOrEmpty(modelVersion))
 			{
@@ -98,8 +98,6 @@ namespace LfMerge.Core
 				argsBldr.Append(" --clone");
 			if (FwProject.AllowDataMigration)
 				argsBldr.Append(" --migrate");
-			if (!string.IsNullOrEmpty(configDir))
-				argsBldr.AppendFormat(" --config \"{0}\"", configDir);
 			startInfo.Arguments = argsBldr.ToString();
 			startInfo.CreateNoWindow = true;
 			startInfo.ErrorDialog = false;

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -82,7 +82,7 @@ namespace LfMerge.Core.MongoConnector
 			var clientSettings = new MongoClientSettings();
 			// clientSettings.WriteConcern = WriteConcern.WMajority; // If increasing the wait queue size still doesn't help, try this as well
 			clientSettings.WaitQueueSize = 50000;
-			clientSettings.Server = new MongoServerAddress(Settings.MongoDbHostName, Settings.MongoDbPort);
+			clientSettings.Server = new MongoServerAddress(Settings.MongoHostname, Settings.MongoPort);
 			return new MongoClient(clientSettings);
 		}
 

--- a/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
@@ -5,18 +5,15 @@ namespace LfMerge.Core.Settings
 {
 	public static class DefaultLfMergeSettings
 	{
-		public const string DefaultIniText = @"
-BaseDir = /tmp/LfMerge.TestApp
-WebworkDir = webwork
-TemplatesDir = Templates
-MongoHostname = localhost
-MongoPort = 27017
-MongoMainDatabaseName = scriptureforge
-MongoDatabaseNamePrefix = sf_
-VerboseProgress = false
-PhpSourcePath = /var/www/languageforge.org/htdocs
-";
-		// optional, usually not set: LanguageDepotRepoUri =
+		public const string BaseDir = "/var/lib/languageforge/lexicon/sendreceive";
+		public const string WebworkDir = "webwork";
+		public const string TemplatesDir = "Templates";
+		public const string MongoHostname = "localhost";
+		public const int MongoPort = 27017;
+		public const string MongoMainDatabaseName = "scriptureforge";
+		public const string MongoDatabaseNamePrefix = "sf_";
+		public const bool VerboseProgress = false;
+		public const string LanguageDepotRepoUri = "";  // optional, usually not set
 	}
 }
 

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -3,11 +3,6 @@
 using System;
 using System.IO;
 using System.Text;
-using IniParser;
-using IniParser.Exceptions;
-using IniParser.Model;
-using IniParser.Model.Configuration;
-using IniParser.Parser;
 using LfMerge.Core.Queues;
 using SIL.LCModel;
 
@@ -15,148 +10,162 @@ namespace LfMerge.Core.Settings
 {
 	public class LfMergeSettings
 	{
-		public static string ConfigDir { get; set; }
+		private string _baseDir = null;
+		private string _webworkDir = null;
+		private string _templatesDir = null;
+		private string _mongoHostname = null;
+		private int _mongoPort = 0;
+		private string _mongoMainDatabaseName = null;
+		private string _mongoDatabaseNamePrefix = null;
+		private string _verboseProgressStr = null;
+		private bool _verboseProgress = false;
+		private string _languageDepotRepoUri = null;
 
-		public static string ConfigFile {
-			get { return Path.Combine(ConfigDir, "sendreceive.conf"); }
+		// Settings derived from environment variables
+
+		public string BaseDir {
+			get {
+				if (_baseDir != null) return _baseDir;
+				else {
+					_baseDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir) ?? DefaultLfMergeSettings.BaseDir;
+					return _baseDir;
+				}
+			}
 		}
 
-		static LfMergeSettings()
-		{
-			if (string.IsNullOrEmpty(ConfigDir))
-				ConfigDir = "/etc/languageforge/conf/";
+		public string WebworkDir {
+			get {
+				if (_webworkDir != null) return _webworkDir;
+				else {
+					_webworkDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir) ?? DefaultLfMergeSettings.WebworkDir;
+					return _webworkDir;
+				}
+			}
 		}
+
+		public string TemplatesDir {
+			get {
+				if (_templatesDir != null) return _templatesDir;
+				else {
+					_templatesDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir) ?? DefaultLfMergeSettings.TemplatesDir;
+					return _templatesDir;
+				}
+			}
+		}
+
+		public string MongoHostname {
+			get {
+				if (_mongoHostname != null) return _mongoHostname;
+				else {
+					_mongoHostname = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoHostname) ?? DefaultLfMergeSettings.MongoHostname;
+					return _mongoHostname;
+				}
+			}
+		}
+
+		public int MongoPort {
+			get {
+				if (_mongoPort != 0) return _mongoPort;
+				else {
+					string mongoPortStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort);
+					if (mongoPortStr == null) mongoPortStr = "";
+					if (Int32.TryParse(mongoPortStr, out _mongoPort)) {
+						return _mongoPort;
+					} else {
+						_mongoPort = DefaultLfMergeSettings.MongoPort;
+						return _mongoPort;
+					}
+				}
+			}
+		}
+
+		public string MongoMainDatabaseName {
+			get {
+				if (_mongoMainDatabaseName != null) return _mongoMainDatabaseName;
+				else {
+					_mongoMainDatabaseName = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoMainDatabaseName) ?? DefaultLfMergeSettings.MongoMainDatabaseName;
+					return _mongoMainDatabaseName;
+				}
+			}
+		}
+
+		/// <summary>
+		/// The prefix prepended to project codes to get the Mongo database name.
+		/// </summary>
+		public string MongoDatabaseNamePrefix {
+			get {
+				if (_mongoDatabaseNamePrefix != null) return _mongoDatabaseNamePrefix;
+				else {
+					_mongoDatabaseNamePrefix = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoDatabaseNamePrefix) ?? DefaultLfMergeSettings.MongoDatabaseNamePrefix;
+					return _mongoDatabaseNamePrefix;
+				}
+			}
+		}
+
+		public bool VerboseProgress {
+			get {
+				if (_verboseProgressStr != null) return _verboseProgress;
+				else {
+					_verboseProgressStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_VerboseProgress);
+					if (_verboseProgressStr == null) _verboseProgressStr = "";
+					_verboseProgress = LanguageForge.Model.ParseBoolean.FromString(_verboseProgressStr);
+					return _verboseProgress;
+				}
+			}
+		}
+
+		public string LanguageDepotRepoUri {
+			get {
+				if (_languageDepotRepoUri != null) return _languageDepotRepoUri;
+				else {
+					_languageDepotRepoUri = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_LanguageDepotRepoUri) ?? DefaultLfMergeSettings.LanguageDepotRepoUri;
+					return _languageDepotRepoUri;
+				}
+			}
+		}
+
+		// Settings calculated at runtime from sources other than environment variables
+
+		public bool CommitWhenDone { get; internal set; }
+
+		public string MongoDbHostNameAndPort { get { return String.Format("{0}:{1}", MongoHostname, MongoPort.ToString()); } }
+
+		private string[] QueueDirectories { get; set; }
+
+		public string StateDirectory { get; private set; }
+
+		public string WebWorkDirectory { get { return LcmDirectorySettings.ProjectsDirectory; } }
+
+		public LcmDirectories LcmDirectorySettings { get; private set; }
 
 		public LfMergeSettings()
 		{
 			LcmDirectorySettings = new LcmDirectories();
-
-			// Save parsed config for easier persisting in SaveSettings()
-			ParsedConfig = this.ParseFiles(DefaultLfMergeSettings.DefaultIniText, ConfigFile);
-			Initialize(ParsedConfig);
+			QueueDirectories = new string[0];
 		}
 
-		protected IniData ParsedConfig { get; set; }
-
-		public void Initialize(IniData parsedConfig)
+		public void Initialize()
 		{
-//			if (Current != null)
-//				return;
+			SetAllMembers();
 
-			KeyDataCollection main = parsedConfig.Global ?? new KeyDataCollection();
-			string baseDir = main["BaseDir"] ?? "/var/lib/languageforge/lexicon/sendreceive";
-			string webworkDir = main["WebworkDir"] ?? "webwork";
-			string templatesDir = main["TemplatesDir"] ?? "Templates";
-			string mongoHostname = main["MongoHostname"] ?? "localhost";
-			string mongoPort = main["MongoPort"] ?? "27017";
-			int mongoPortAsInt;
-			if (Int32.TryParse(mongoPort, out mongoPortAsInt))
-				{ } // No need to do anything if Mongo port parses correctly as an int
-			else
-				mongoPortAsInt = 27017; // Default to Mongo's default port if settings value can't parse
-			string mongoMainDatabaseName = main["MongoMainDatabaseName"] ?? "scriptureforge";
-			string mongoDatabaseNamePrefix = main["MongoDatabaseNamePrefix"] ?? "sf_";
-			string verboseProgress = main["VerboseProgress"] ?? "";
-			string phpSourcePath = main["PhpSourcePath"] ?? "/var/www/languageforge.org/htdocs";
-
-			SetAllMembers(baseDir, webworkDir, templatesDir, mongoHostname, mongoPortAsInt,
-				mongoDatabaseNamePrefix, mongoMainDatabaseName, verboseProgress, phpSourcePath);
-
-			LanguageDepotRepoUri = main["LanguageDepotRepoUri"]; // optional
-
-			// TODO: Should this CreateDirectories() call live somewhere else?
+			// TODO: Get rid of this once we simplify the queue system. 2022-02 RM
 			Queue.CreateQueueDirectories(this);
 		}
 
-		private string[] QueueDirectories { get; set; }
-
-		private void SetAllMembers(string baseDir, string webworkDir, string templatesDir,
-			string mongoHostname, int mongoPort, string mongoDatabaseNamePrefix,
-			string mongoMainDatabaseName, string verboseProgress, string phpSourcePath)
+		private void SetAllMembers()
 		{
-			LcmDirectorySettings.SetProjectsDirectory(Path.IsPathRooted(webworkDir) ? webworkDir : Path.Combine(baseDir, webworkDir));
-			LcmDirectorySettings.SetTemplateDirectory(Path.IsPathRooted(templatesDir) ? templatesDir : Path.Combine(baseDir, templatesDir));
-			StateDirectory = Path.Combine(baseDir, "state");
+			LcmDirectorySettings.SetProjectsDirectory(Path.IsPathRooted(WebworkDir) ? WebworkDir : Path.Combine(BaseDir, WebworkDir));
+			LcmDirectorySettings.SetTemplateDirectory(Path.IsPathRooted(TemplatesDir) ? TemplatesDir : Path.Combine(BaseDir, TemplatesDir));
+			StateDirectory = Path.Combine(BaseDir, "state");
 
 			CommitWhenDone = true;
-			VerboseProgress = LanguageForge.Model.ParseBoolean.FromString(verboseProgress);
 
 			var queueCount = Enum.GetValues(typeof(QueueNames)).Length;
 			QueueDirectories = new string[queueCount];
 			QueueDirectories[(int)QueueNames.None] = null;
-			QueueDirectories[(int)QueueNames.Edit] = Path.Combine(baseDir, "editqueue");
-			QueueDirectories[(int)QueueNames.Synchronize] = Path.Combine(baseDir, "syncqueue");
-
-			MongoDatabaseNamePrefix = mongoDatabaseNamePrefix;
-			MongoDbHostNameAndPort = String.Format("{0}:{1}", mongoHostname, mongoPort.ToString());
-			MongoDbHostName = mongoHostname;
-			MongoDbPort = mongoPort;
-			MongoMainDatabaseName = mongoMainDatabaseName;
-
-			PhpSourcePath = phpSourcePath;
+			QueueDirectories[(int)QueueNames.Edit] = Path.Combine(BaseDir, "editqueue");
+			QueueDirectories[(int)QueueNames.Synchronize] = Path.Combine(BaseDir, "syncqueue");
 		}
-
-		public bool CommitWhenDone { get; internal set; }
-
-		public bool VerboseProgress { get; protected set; }
-
-		public string PhpSourcePath { get; protected set; }
-
-		public string LanguageDepotRepoUri { get; protected set; }
-
-		#region Equality and GetHashCode
-
-		public override bool Equals(object obj)
-		{
-			var other = obj as LfMergeSettings;
-			if (other == null)
-				return false;
-			bool ret =
-				other.CommitWhenDone == CommitWhenDone &&
-				other.LcmDirectorySettings.DefaultProjectsDirectory == LcmDirectorySettings.DefaultProjectsDirectory &&
-				other.MongoDatabaseNamePrefix == MongoDatabaseNamePrefix &&
-				other.MongoDbHostNameAndPort == MongoDbHostNameAndPort &&
-				other.MongoDbHostName == MongoDbHostName &&
-				other.MongoDbPort == MongoDbPort &&
-				other.MongoMainDatabaseName == MongoMainDatabaseName &&
-				other.LcmDirectorySettings.ProjectsDirectory == LcmDirectorySettings.ProjectsDirectory &&
-				other.StateDirectory == StateDirectory &&
-				other.LcmDirectorySettings.TemplateDirectory == LcmDirectorySettings.TemplateDirectory &&
-				other.VerboseProgress == VerboseProgress &&
-				other.WebWorkDirectory == WebWorkDirectory;
-			foreach (QueueNames queueName in Enum.GetValues(typeof(QueueNames)))
-			{
-				ret = ret && other.GetQueueDirectory(queueName) == GetQueueDirectory(queueName);
-			}
-			return ret;
-		}
-
-		public override int GetHashCode()
-		{
-			var hash = CommitWhenDone.GetHashCode() ^
-				LcmDirectorySettings.DefaultProjectsDirectory.GetHashCode() ^
-				MongoDatabaseNamePrefix.GetHashCode() ^
-				MongoDbHostNameAndPort.GetHashCode() ^
-				MongoDbHostName.GetHashCode() ^
-				MongoDbPort.GetHashCode() ^
-				MongoMainDatabaseName.GetHashCode() ^
-				LcmDirectorySettings.ProjectsDirectory.GetHashCode() ^
-				StateDirectory.GetHashCode() ^
-				LcmDirectorySettings.TemplateDirectory.GetHashCode() ^
-				VerboseProgress.GetHashCode() ^
-				WebWorkDirectory.GetHashCode();
-			foreach (QueueNames queueName in Enum.GetValues(typeof(QueueNames)))
-			{
-				var dir = GetQueueDirectory(queueName);
-				if (dir != null)
-					hash ^= dir.GetHashCode();
-			}
-			return hash;
-		}
-
-		#endregion
-
-		public LcmDirectories LcmDirectorySettings { get; private set; }
 
 		public class LcmDirectories: ILcmDirectories
 		{
@@ -174,6 +183,7 @@ namespace LfMerge.Core.Settings
 
 			public string ProjectsDirectory { get; private set; }
 
+			// TODO: What is the point of this? Determine if we can get rid of it. 2022-02 RM
 			public string DefaultProjectsDirectory {
 				get { return ProjectsDirectory; }
 			}
@@ -182,8 +192,6 @@ namespace LfMerge.Core.Settings
 
 			#endregion
 		}
-
-		public string StateDirectory { get; private set; }
 
 		public string LockFile
 		{
@@ -211,8 +219,6 @@ namespace LfMerge.Core.Settings
 			return QueueDirectories[(int)queue];
 		}
 
-		public string WebWorkDirectory { get { return LcmDirectorySettings.ProjectsDirectory; } }
-
 		/// <summary>
 		/// Gets the name of the state file. If necessary the state directory is also created.
 		/// </summary>
@@ -223,92 +229,6 @@ namespace LfMerge.Core.Settings
 			Directory.CreateDirectory(StateDirectory);
 			return Path.Combine(StateDirectory, projectCode + ".state");
 		}
-
-		public string MongoDbHostNameAndPort { get; private set; }
-
-		public string MongoDbHostName { get; private set; }
-
-		public int MongoDbPort { get; private set; }
-
-		public string MongoMainDatabaseName { get; private set; }
-
-		/// <summary>
-		/// The prefix prepended to project codes to get the Mongo database name.
-		/// </summary>
-		public string MongoDatabaseNamePrefix { get; private set; }
-
-		#region Serialization/Deserialization
-
-		// we don't call this method from our production code since LfMerge doesn't directly
-		// change the option.
-		public void SaveSettings()
-		{
-			SaveSettings(ConfigFile);
-		}
-
-		private static IniParserConfiguration CreateIniParserConfiguration()
-		{
-			return new IniParserConfiguration {
-				// ThrowExceptionsOnError = false,
-				CommentString = "#",
-				SkipInvalidLines = true
-			};
-		}
-
-		public void SaveSettings(string fileName)
-		{
-			if (ParsedConfig == null)
-				ParsedConfig = new IniData();
-			// Note that this will persist the merged global & user configurations, not the original global config.
-			// Since we don't call this method from production code, this is not an issue.
-			var parserConfig = CreateIniParserConfiguration();
-			var parser = new IniDataParser(parserConfig);
-			var fileParser = new FileIniDataParser(parser);
-			var utf8 = new UTF8Encoding(false);
-			fileParser.WriteFile(fileName, ParsedConfig, utf8);
-		}
-
-		public virtual IniData ParseFiles(string defaultConfig, string globalConfigFilename)
-		{
-			var utf8 = new UTF8Encoding(false);
-			var parserConfig = CreateIniParserConfiguration();
-
-			var parser = new IniDataParser(parserConfig);
-			IniData result = parser.Parse(DefaultLfMergeSettings.DefaultIniText);
-
-			string globalIni = File.Exists(globalConfigFilename) ? File.ReadAllText(globalConfigFilename, utf8) : "";
-			if (String.IsNullOrEmpty(globalIni))
-			{
-				// Can't use the log yet, so report warnings to Console.WriteLine
-				Console.WriteLine("LfMerge: Warning: no global configuration found. Will use default settings.");
-			}
-			IniData globalConfig;
-			try
-			{
-				globalConfig = parser.Parse(globalIni);
-			}
-			catch (ParsingException e)
-			{
-				Console.WriteLine("LfMerge: Warning: Error parsing global configuration file. Will use default settings.");
-				Console.WriteLine("Error follows: {0}", e.ToString());
-				globalConfig = null; // Merging null is perfectly acceptable to IniParser
-			}
-			result.Merge(globalConfig);
-
-			foreach (KeyData item in result.Global)
-			{
-				// Special-case. Could be replaced with a more general regex if we end up using more variables, but YAGNI.
-				if (item.Value.Contains("${HOME}"))
-				{
-					item.Value = item.Value.Replace("${HOME}", Environment.GetEnvironmentVariable("HOME"));
-				}
-			}
-
-			return result;
-		}
-
-		#endregion
-
 	}
 }
 

--- a/src/LfMerge/Options.cs
+++ b/src/LfMerge/Options.cs
@@ -28,9 +28,6 @@ namespace LfMerge
 		[Option("migrate", HelpText = "Allow data migration")]
 		public bool AllowDataMigration { get; set; }
 
-		[Option("config", HelpText = "Alternate location of the 'sendreceive.conf' configuration file")]
-		public string ConfigDir { get; set; }
-
 		[Option("user", HelpText = "LanguageDepot username (for debugging purposes only)", DefaultValue = "x")]
 		public string User { get; set; }
 

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -47,9 +47,6 @@ namespace LfMerge
 				return -1;
 			}
 
-			if (!string.IsNullOrEmpty(options.ConfigDir))
-				LfMergeSettings.ConfigDir = options.ConfigDir;
-
 			FwProject.AllowDataMigration = options.AllowDataMigration;
 
 			string differentModelVersion = null;
@@ -79,7 +76,7 @@ namespace LfMerge
 			if (!string.IsNullOrEmpty(differentModelVersion))
 			{
 				result = MainClass.StartLfMerge(options.ProjectCode, options.CurrentAction,
-					differentModelVersion, false, options.ConfigDir);
+					differentModelVersion, false);
 			}
 
 			MainClass.Logger.Notice("LfMerge-{0} finished", MainClass.ModelVersion);


### PR DESCRIPTION
WIP. Once I finish changing all the places that reference LfMergeSettings (particularly in the test code that's pretty tightly coupled to the current implementation, which it mocks), LfMerge will get its settings from environment variables instead of an .ini file, allowing easier containerization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/197)
<!-- Reviewable:end -->
