### PR TITLE
Hopefully speed up Docker image pull

### DIFF
--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -6,7 +6,7 @@ WORKDIR /build/lfmerge
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
-RUN apt-get update && apt-get install -y gnupg
+RUN apt-get update && apt-get install -y gnupg && rm -rf /var/lib/apt/lists/*
 
 COPY docker/sil-packages-key.gpg .
 COPY docker/sil-packages-testing-key.gpg .
@@ -15,7 +15,7 @@ RUN apt-key add sil-packages-testing-key.gpg
 RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
 RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
 # Dependencies from Debian "control" file
-RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
+RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo && rm -rf /var/lib/apt/lists/*
 
 # Ensure fieldworks group exists in case lfmerge-fdo package didn't install it, and that www-data is part of that group
 # Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists


### PR DESCRIPTION
This should hopefully speed up pulling Docker images for lfmerge by making the "apt-get" steps more consistent and more likely to have cache hits, thereby making the big image layers more likely to be in common between different builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/206)
<!-- Reviewable:end -->
