### PR TITLE
Fix race condition in Docker build tagging

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -155,8 +155,10 @@ jobs:
         run: |
           echo Will tag ${{matrix.dbversion}} with ${TAG}
           echo "::set-output name=TagFor${{matrix.dbversion}}::${TAG}"
+          echo "::set-output name=VersionFor${{matrix.dbversion}}::${VERSION}"
         env:
           TAG: v${{ steps.version.outputs.MsBuildVersion }}
+          VERSION: ${{ steps.version.outputs.MsBuildVersion }}
 
       - name: Set up buildx for Docker
         # docker/setup-buildx-action@v1.6.0 is commit 94ab11c41e45d028884a99163086648e898eed25
@@ -203,7 +205,7 @@ jobs:
           name: lfmerge-tarball
           path: tarball
     outputs:
-      MsBuildVersion: ${{ steps.version.outputs.MsBuildVersion }}
+      MsBuildVersion: ${{ steps.output_version_number.outputs.VersionFor7000072 }}
       TagFor7000068: ${{ steps.output_version_number.outputs.TagFor7000068 }}
       TagFor7000069: ${{ steps.output_version_number.outputs.TagFor7000069 }}
       TagFor7000070: ${{ steps.output_version_number.outputs.TagFor7000070 }}


### PR DESCRIPTION
The Docker build used the variable MsBuildVersion to construct the Docker tag. But that variable had a different value in the FW 8 and FW 9 builds, and there was a race condition. If the FW 9 build finished last (which happens most of the time), its value went into the final output. But if one of the FW 8 builds finished last, then its value for MsBuildVersion would overwrite the one that was there from FW 9. By giving each variable a different name, we avoid that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/208)
<!-- Reviewable:end -->
