### PR TITLE
Fix exec permissions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,15 @@ jobs:
         mkdir -p tarball/lfmerge-7000072 || true
         mkdir -p tarball/lfmerge || true
 
+    - name: Restore executable bits
+      # GitHub artifacts system strips executable bits, so restore them here
+      run: |
+        chmod +x tarball/lfmerge*/usr/bin/lfmerge
+        chmod +x tarball/lfmerge*/usr/bin/lfmergeqm
+        chmod +x tarball/lfmerge*/usr/lib/lfmerge/*/chorusmerge
+        chmod +x tarball/lfmerge*/usr/lib/lfmerge/*/startlfmerge
+        chmod +x tarball/lfmerge*/usr/lib/lfmerge/*/Mercurial/hg
+
     - name: Login to GHCR
       if: github.event_name == 'push' && github.ref == 'refs/heads/live'
       uses: docker/login-action@v1


### PR DESCRIPTION
The exec bit is stripped by the upload-artifacts / download-artifacts steps. We'll restore it immediately after downloading artifacts.

Fixes https://github.com/sillsdev/web-languageforge/issues/1387.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/210)
<!-- Reviewable:end -->
