### PR TITLE
When missing a setup folder, log complete list

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -152,6 +152,7 @@ namespace LfMerge.Core
 				if (!Directory.Exists(folderPath))
 				{
 					Logger.Notice("Folder '{0}' doesn't exist", folderPath);
+					Logger.Notice("Folder paths searched: {0}", string.Join(":", folderPaths));
 					return false;
 				}
 			}


### PR DESCRIPTION
This will help with a bug where the lfmerge container is printing `Folder '' doesn't exist` in some circumstances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/213)
<!-- Reviewable:end -->
