### PR TITLE
Do not cause release to fail if tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
       run: |
         git config --global user.name "github-actions"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git tag -a -m "Release ${TAG70}" "${TAG70}" "refs/remotes/origin/${FW8Branch}"
-        git tag -a -m "Release ${TAG72}" "${TAG72}" "refs/remotes/origin/${FW9Branch}"
+        git tag -f -a -m "Release ${TAG70}" "${TAG70}" "refs/remotes/origin/${FW8Branch}"
+        git tag -f -a -m "Release ${TAG72}" "${TAG72}" "refs/remotes/origin/${FW9Branch}"
         git push -v origin "${TAG70}" "${TAG72}"
 
     - name: Download build artifacts


### PR DESCRIPTION
There are some circumstances where the release tag being pushed already
exists; most notably, a bugfix that only applies to FW 9 or FW 8 and
therefore was only applied to one branch. The other branch would build
the same tag over again, and should not fail just because the tag can't
be created a second time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/216)
<!-- Reviewable:end -->
