### PR TITLE
Fix webwork dir not being an absolute path

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -152,7 +152,6 @@ namespace LfMerge.Core
 				if (!Directory.Exists(folderPath))
 				{
 					Logger.Notice("Folder '{0}' doesn't exist", folderPath);
-					Logger.Notice("Folder paths searched: {0}", string.Join(":", folderPaths));
 					return false;
 				}
 			}

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -38,6 +38,7 @@ namespace LfMerge.Core.Settings
 				if (_webworkDir != null) return _webworkDir;
 				else {
 					_webworkDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir) ?? DefaultLfMergeSettings.WebworkDir;
+					_webworkDir = Path.IsPathRooted(_webworkDir) ? _webworkDir : Path.Combine(BaseDir, _webworkDir);
 					return _webworkDir;
 				}
 			}
@@ -48,6 +49,7 @@ namespace LfMerge.Core.Settings
 				if (_templatesDir != null) return _templatesDir;
 				else {
 					_templatesDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir) ?? DefaultLfMergeSettings.TemplatesDir;
+					_templatesDir = Path.IsPathRooted(_templatesDir) ? _templatesDir : Path.Combine(BaseDir, _templatesDir);
 					return _templatesDir;
 				}
 			}
@@ -154,8 +156,8 @@ namespace LfMerge.Core.Settings
 
 		private void SetAllMembers()
 		{
-			LcmDirectorySettings.SetProjectsDirectory(Path.IsPathRooted(WebworkDir) ? WebworkDir : Path.Combine(BaseDir, WebworkDir));
-			LcmDirectorySettings.SetTemplateDirectory(Path.IsPathRooted(TemplatesDir) ? TemplatesDir : Path.Combine(BaseDir, TemplatesDir));
+			LcmDirectorySettings.SetProjectsDirectory(WebworkDir);
+			LcmDirectorySettings.SetTemplateDirectory(TemplatesDir);
 			StateDirectory = Path.Combine(BaseDir, "state");
 
 			CommitWhenDone = true;


### PR DESCRIPTION
The queue manager was exiting early, printing "Folder '' doesn't exist". It turns out that this is because the code that sets WebworkDir to an absolute path (based off of BaseDir) wasn't being run in that code path. We now move that code path to the location of the WebworkDir property, and we'll have it working again.

There will be no FW 8 version of this PR, because this bugfix is already included in PR #217.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/218)
<!-- Reviewable:end -->
