### PR TITLE
Fix lfmergeqm not getting right settings

### DIFF
--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -33,6 +33,7 @@ namespace LfMerge.QueueManager
 			Sldr.Initialize();
 
 			var settings = MainClass.Container.Resolve<LfMergeSettings>();
+			settings.Initialize();
 			var fileLock = SimpleFileLock.CreateFromFilePath(settings.LockFile);
 			try
 			{


### PR DESCRIPTION
The LfMergeSettings class needs to be initialized before it's used, and
the queue manager wasn't calling Initialize(). Fixed now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/219)
<!-- Reviewable:end -->
