### PR TITLE
Fix lfmergeqm not getting right settings

### DIFF
--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -29,6 +29,7 @@ namespace LfMerge.QueueManager
 			MainClass.Logger.Notice("LfMergeQueueManager starting with args: {0}", string.Join(" ", args));
 
 			var settings = MainClass.Container.Resolve<LfMergeSettings>();
+			settings.Initialize();
 			var fileLock = SimpleFileLock.CreateFromFilePath(settings.LockFile);
 			try
 			{


### PR DESCRIPTION
The LfMergeSettings class needs to be initialized before it's used, and
the queue manager wasn't calling Initialize(). Fixed now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/220)
<!-- Reviewable:end -->
