### PR TITLE
Initialize LfMergeSettings before use

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -144,6 +144,7 @@ namespace LfMerge.Core
 		public static bool CheckSetup()
 		{
 			var settings = Container.Resolve<LfMergeSettings>();
+			settings.Initialize();
 			var homeFolder = Environment.GetEnvironmentVariable("HOME") ?? "/var/www";
 			string[] folderPaths = { Path.Combine(homeFolder, ".local"),
 				Path.GetDirectoryName(settings.WebWorkDirectory) };


### PR DESCRIPTION
#219 left out one other place where LfMergeSettings needed its Initialize() method called.