### PR TITLE
Fix LfMerge settings from env vars (FW8)

### DIFF
--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -52,6 +52,7 @@ RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue && ch
 
 # TODO: Turn this into environment variables, because we want to be able to just set env vars in k8s config and restart the container
 COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf
+COPY sudoers.d.lfmerge.conf /etc/sudoers.d/lfmerge
 COPY mercurial-cacerts.rc /etc/mercurial/hgrc
 COPY lfmergeqm-background.sh /
 COPY lfmergeqm-looping.sh /

--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -126,7 +126,6 @@ namespace LfMerge.Core
 		public static bool CheckSetup()
 		{
 			var settings = MainClass.Container.Resolve<LfMergeSettings>();
-			settings.Initialize();
 			var homeFolder = Environment.GetEnvironmentVariable("HOME") ?? "/var/www";
 			string[] folderPaths = { Path.Combine(homeFolder, ".local"),
 				Path.GetDirectoryName(settings.WebWorkDirectory) };

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -144,12 +144,11 @@ namespace LfMerge.Core.Settings
 		{
 			FdoDirectorySettings = new FdoDirectories();
 			QueueDirectories = new string[0];
+			SetAllMembers();
 		}
 
 		public void Initialize()
 		{
-			SetAllMembers();
-
 			// TODO: Get rid of this once we simplify the queue system. 2022-02 RM
 			Queue.CreateQueueDirectories(this);
 		}

--- a/sudoers.d.lfmerge.conf
+++ b/sudoers.d.lfmerge.conf
@@ -1,0 +1,1 @@
+Defaults env_keep += "LFMERGE_*"


### PR DESCRIPTION
Turns out `sudo` resets environment variables except for those appearing
on a whitelist. So we ensure that all LFMERGE_* variables appear on the
whitelist in the LfMerge container.

We also move the SetAllMembers() call in LfMergeSettings into the
constructor, because there's no reason for it to be in Initialize().

These two changes are enough to fix the bugs that were causing LfMerge
settings not to be picked up by the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/224)
<!-- Reviewable:end -->
