### PR TITLE
Docker doesn't handle curly braces properly

### DIFF
--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -48,7 +48,7 @@ ADD tarball/lfmerge-7000072/ /
 
 ADD tarball/lfmerge/ /
 
-RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/{syncqueue,webwork,Templates,state} && chown -R www-data:www-data /var/lib/languageforge
+RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue /var/lib/languageforge/lexicon/sendreceive/webwork /var/lib/languageforge/lexicon/sendreceive/Templates /var/lib/languageforge/lexicon/sendreceive/state && chown -R www-data:www-data /var/lib/languageforge
 
 # TODO: Turn this into environment variables, because we want to be able to just set env vars in k8s config and restart the container
 COPY lfmerge.conf /etc/languageforge/conf/sendreceive.conf


### PR DESCRIPTION
In Dockerfiles, curly-brace expansion doesn't work properly. So we have to write it out the long way instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/228)
<!-- Reviewable:end -->
