### PR TITLE
Slimmer LfMerge images

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,0 +1,43 @@
+name: build-base-image
+
+on:
+  # Only run this workflow manually, to ensure it WON'T run with every commit
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v3.0.2
+
+    - name: Set up buildx for Docker
+      # docker/setup-buildx-action@v2.0.0 is commit dc7b9719a96d48369863986a06765841d7ea23f6
+      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+
+    - name: Login to GHCR
+      # docker/login-action@v2.0.0 is commit 49ed152c8eca782a232dede0303416e8f356c37b
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build base Docker image
+      id: lfmerge_base_image
+      # docker/build-push-action@v3.0.0 is commit e551b19e49efd4e98792db7592c17c09b89db8d8
+      uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+      with:
+        push: true
+        tags: ghcr.io/sillsdev/lfmerge-base:latest
+        context: docker
+        file: Dockerfile.base
+
+    - name: Show metadata from LfMerge image build step
+      run: echo "$METADATA"
+      env:
+        METADATA: ${{ steps.lfmerge_base_image.output.metadata }}
+
+    - name: List Docker images to verify build
+      run: docker image ls


### PR DESCRIPTION
We'll split the base image off from the rest of the LfMerge image, and NOT re-run it with every LfMerge build. Since it contains a large layer (700MB compressed, 1.8GB or so uncompressed) that's just the result of `sudo apt install lots-of-dependencies`, and those dependencies do NOT change very often, splitting this part off into a base image that is only re-run manually will save us a lot of download time in the long run.

This PR is part 1 of 2. The workflow needs to be in the default branch (`master`, in this case) in order to run. Once it's in the branch, I can run it and get the base image pushed to GHCR. Then I can create the PR for part 2 which will use the base image from GHCR as the baseline image for the build *and* run images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/234)
<!-- Reviewable:end -->
