### PR TITLE
Slimmer LfMerge images (FW8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,7 @@
 # syntax=docker/dockerfile:experimental
 ARG DbVersion=7000072
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-builder-base
-WORKDIR /build/lfmerge
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
-RUN apt-get update && apt-get install -y gnupg
-
-COPY docker/sil-packages-key.gpg .
-COPY docker/sil-packages-testing-key.gpg .
-RUN apt-key add sil-packages-key.gpg
-RUN apt-key add sil-packages-testing-key.gpg
-RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
-RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
-# Dependencies from Debian "control" file
-RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo
+FROM ghcr.io/sillsdev/lfmerge-base AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -1,29 +1,7 @@
 # syntax=docker/dockerfile:experimental
 ARG DbVersion=7000072
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-base
-WORKDIR /build/lfmerge
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
-RUN apt-get update && apt-get install -y gnupg && rm -rf /var/lib/apt/lists/*
-
-COPY docker/sil-packages-key.gpg .
-COPY docker/sil-packages-testing-key.gpg .
-RUN apt-key add sil-packages-key.gpg
-RUN apt-key add sil-packages-testing-key.gpg
-RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
-RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
-# Dependencies from Debian "control" file
-RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo && rm -rf /var/lib/apt/lists/*
-
-# Ensure fieldworks group exists in case lfmerge-fdo package didn't install it, and that www-data is part of that group
-# Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists
-RUN addgroup --system --quiet fieldworks ; \
-    adduser --quiet www-data fieldworks ; \
-	install -d -o www-data -g www-data -m 02775 /var/www/.local
-
-FROM lfmerge-base AS lfmerge
+FROM ghcr.io/sillsdev/lfmerge-base
 
 # install LFMerge prerequisites
 # python - required by Mercurial, which is bundled in the LFMerge installation


### PR DESCRIPTION
We now build from a base image stored in the GitHub Container Registry.
By storing the base image in GHCR and only updating it when once of the
lfmerge dependencies changes (which almost never happens), we can avoid
re-running `apt-get update` all the time, which always ends up causing a
layer change and the entire 700MB layer to be different. This results in
much slimmer lfmerge images and faster download times.

This is PR #236, for fieldworks8-master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/237)
<!-- Reviewable:end -->
