### PR TITLE
Remove some unnecessary using directives

### DIFF
--- a/src/FixFwData/Program.cs
+++ b/src/FixFwData/Program.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using LfMerge.Core.Logging;
 using SIL.LCModel.FixData;
 using SIL.LCModel.Utils;
-//using SIL.Reporting;
 using SyslogLogger = SIL.Linux.Logging.SyslogLogger;
 using SIL.PlatformUtilities;
 

--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -19,7 +19,6 @@ using LfMerge.Core.Reporting;
 using LfMerge.Core.Settings;
 using SIL.IO;
 using SIL.LCModel;
-using SIL.PlatformUtilities;
 using SIL.Progress;
 using Action = LfMerge.Core.Actions.Action;
 

--- a/src/LfMerge/Options.cs
+++ b/src/LfMerge/Options.cs
@@ -3,7 +3,6 @@
 using CommandLine;
 using CommandLine.Text;
 using LfMerge.Core.Actions;
-using System.IO;
 
 namespace LfMerge
 {


### PR DESCRIPTION
Minor code cleanup, mostly so that a new LfMerge build will run using the lfmerge-base image and I can compare the resulting download size to what it used to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/238)
<!-- Reviewable:end -->
