### PR TITLE
Remove some unnecessary using directives (FW8)

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -17,7 +17,6 @@ using LfMerge.Core.Queues;
 using LfMerge.Core.Reporting;
 using LfMerge.Core.Settings;
 using Palaso.IO;
-using Palaso.PlatformUtilities;
 using Palaso.Progress;
 using SIL.FieldWorks.FDO;
 

--- a/src/LfMerge/Options.cs
+++ b/src/LfMerge/Options.cs
@@ -3,7 +3,6 @@
 using CommandLine;
 using CommandLine.Text;
 using LfMerge.Core.Actions;
-using System.IO;
 
 namespace LfMerge
 {


### PR DESCRIPTION
Minor code cleanup, mostly so that a new LfMerge build will run using the lfmerge-base image and I can compare the resulting download size to what it used to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/239)
<!-- Reviewable:end -->
