### PR TITLE
Get unit tests running again in Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 data/
 !data/testlangproj
+!data/testlangproj-modified
 finalresults*
 Dockerfile
 packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
 	chown -R builder:users /build
 
+# Unit tests need specific permissions on /var/lib/languageforge
+RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue \
+    /var/lib/languageforge/lexicon/sendreceive/webwork \
+    /var/lib/languageforge/lexicon/sendreceive/Templates \
+    /var/lib/languageforge/lexicon/sendreceive/state \
+    && chown -R builder:users /var/lib/languageforge
+
 # Any setup unique to the various builds goes in one of these four images
 FROM lfmerge-builder-base AS lfmerge-build-7000068
 ENV DbVersion=7000068

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,15 @@ RUN mkdir -m 02775 -p /var/lib/languageforge/lexicon/sendreceive/syncqueue \
     /var/lib/languageforge/lexicon/sendreceive/state \
     && chown -R builder:users /var/lib/languageforge
 
+ARG RunUnitTests=0
+ARG ExcludeCategories=IntegrationTests
+ENV RUN_UNIT_TESTS=$RunUnitTests
+ENV UNIT_TEST_EXCLUSIONS=$ExcludeCategories
+
 # Any setup unique to the various builds goes in one of these four images
 FROM lfmerge-builder-base AS lfmerge-build-7000068
 ENV DbVersion=7000068
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000068
-ENV RUN_UNIT_TESTS=0
 ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # To run specific unit tests, set TEST_SPEC env var, e.g.:
@@ -33,7 +37,6 @@ ENV NUNIT_VERSION_MAJOR=2
 FROM lfmerge-builder-base AS lfmerge-build-7000069
 ENV DbVersion=7000069
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000069
-ENV RUN_UNIT_TESTS=0
 ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
@@ -41,7 +44,6 @@ ENV NUNIT_VERSION_MAJOR=2
 FROM lfmerge-builder-base AS lfmerge-build-7000070
 ENV DbVersion=7000070
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000070
-ENV RUN_UNIT_TESTS=0
 ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=1
 ENV NUNIT_VERSION_MAJOR=2
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
@@ -49,7 +51,6 @@ ENV NUNIT_VERSION_MAJOR=2
 FROM lfmerge-builder-base AS lfmerge-build-7000072
 ENV DbVersion=7000072
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000072
-ENV RUN_UNIT_TESTS=0
 ENV UPDATE_ASSEMBLYINFO_BY_SCRIPT=0
 ENV NUNIT_VERSION_MAJOR=3
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync

--- a/docker/scripts/test-lfmerge-combined.sh
+++ b/docker/scripts/test-lfmerge-combined.sh
@@ -20,5 +20,5 @@ if [ -n "$TEST_SPEC" ]; then
     mono packages/NUnit.ConsoleRunner/tools/nunit3-console.exe output/Release/LfMerge*.Tests.dll --test "$TEST_SPEC"
   fi
 else
-  msbuild /t:TestOnly /v:detailed /property:Configuration=Release build/LfMerge.proj
+  msbuild /t:TestOnly /v:detailed /property:Configuration=Release /property:ExtraExcludeCategories="$UNIT_TEST_EXCLUSIONS" build/LfMerge.proj
 fi

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -82,12 +82,14 @@ if [ "${BUILD_FW8}" -eq 0 ]; then
 	docker build --build-arg DbVersion=7000072 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000072 .
 else
 	time parallel --no-notice <<EOF
-docker build --build-arg DbVersion=7000068 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000068 .
-docker build --build-arg DbVersion=7000069 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000069 .
-docker build --build-arg DbVersion=7000070 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000070 .
-docker build --build-arg DbVersion=7000072 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000072 .
+docker build --build-arg "RunUnitTests=1" --build-arg DbVersion=7000068 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000068 .
+docker build --build-arg "RunUnitTests=1" --build-arg DbVersion=7000069 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000069 .
+docker build --build-arg "RunUnitTests=1" --build-arg DbVersion=7000070 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000070 .
+docker build --build-arg "RunUnitTests=1" --build-arg DbVersion=7000072 --build-arg "BUILDER_UID=${CURRENT_UID}" -t lfmerge-build-7000072 .
 EOF
 fi
+
+# TODO: Make unit testing (--build-arg "RunUnitTests=1") controllable by a pbuild.sh flag
 
 # To run a single build instead, comment out the block above and uncomment the next line (and change 72 to 68/69/70 if needed)
 # docker build --build-arg DbVersion=7000072 -t lfmerge-build-7000072 -f combined.dockerfile .

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016-2018 SIL International
+// Copyright (c) 2016-2018 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/src/LfMerge.Core.Tests/Lcm/LcmTestBase.cs
+++ b/src/LfMerge.Core.Tests/Lcm/LcmTestBase.cs
@@ -45,6 +45,7 @@ namespace LfMerge.Core.Tests.Lcm
 				languageForgeServerFolder: LanguageForgeFolder
 			);
 			Settings = new LfMergeSettingsDouble(LanguageForgeFolder.Path);
+			Settings.Initialize();
 			TestEnvironment.CopyFwProjectTo(testProjectCode, Settings.LcmDirectorySettings.DefaultProjectsDirectory);
 			lfProj = LanguageForgeProject.Create(testProjectCode);
 		}

--- a/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
+++ b/src/LfMerge.Core.Tests/Settings/LfMergeSettingsTests.cs
@@ -22,6 +22,7 @@ namespace LfMerge.Core.Tests
 					System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir, webworkDir);
 				if (!string.IsNullOrEmpty(templateDir))
 					System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir, templateDir);
+				base.SetAllMembers();
 				base.Initialize();
 			}
 		}

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -85,6 +85,7 @@ namespace LfMerge.Core.Tests
 		{
 			System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir, replacementBaseDir);
 			System.Environment.SetEnvironmentVariable(MagicStrings.SettingsEnvVar_VerboseProgress, "true");
+			base.SetAllMembers();
 			base.Initialize();
 			CommitWhenDone = false;
 		}

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -10,121 +10,56 @@ namespace LfMerge.Core.Settings
 {
 	public class LfMergeSettings
 	{
-		private string _baseDir = null;
-		private string _webworkDir = null;
-		private string _templatesDir = null;
-		private string _mongoHostname = null;
-		private int _mongoPort = 0;
-		private string _mongoMainDatabaseName = null;
-		private string _mongoDatabaseNamePrefix = null;
-		private string _verboseProgressStr = null;
-		private bool _verboseProgress = false;
-		private string _languageDepotRepoUri = null;
-
 		// Settings derived from environment variables
 
-		public string BaseDir {
-			get {
-				if (_baseDir != null) return _baseDir;
-				else {
-					_baseDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir) ?? DefaultLfMergeSettings.BaseDir;
-					return _baseDir;
-				}
-			}
-		}
+		public string BaseDir => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_BaseDir) ?? DefaultLfMergeSettings.BaseDir;
 
 		public string WebworkDir {
 			get {
-				if (_webworkDir != null) return _webworkDir;
-				else {
-					_webworkDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir) ?? DefaultLfMergeSettings.WebworkDir;
-					_webworkDir = Path.IsPathRooted(_webworkDir) ? _webworkDir : Path.Combine(BaseDir, _webworkDir);
-					return _webworkDir;
-				}
+					string webworkDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_WebworkDir) ?? DefaultLfMergeSettings.WebworkDir;
+					webworkDir = Path.IsPathRooted(webworkDir) ? webworkDir : Path.Combine(this.BaseDir, webworkDir);
+					return webworkDir;
 			}
 		}
 
 		public string TemplatesDir {
 			get {
-				if (_templatesDir != null) return _templatesDir;
-				else {
-					_templatesDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir) ?? DefaultLfMergeSettings.TemplatesDir;
-					_templatesDir = Path.IsPathRooted(_templatesDir) ? _templatesDir : Path.Combine(BaseDir, _templatesDir);
-					return _templatesDir;
-				}
+					string templatesDir = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_TemplatesDir) ?? DefaultLfMergeSettings.TemplatesDir;
+					templatesDir = Path.IsPathRooted(templatesDir) ? templatesDir : Path.Combine(BaseDir, templatesDir);
+					return templatesDir;
 			}
 		}
 
-		public string MongoHostname {
-			get {
-				if (_mongoHostname != null) return _mongoHostname;
-				else {
-					_mongoHostname = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoHostname) ?? DefaultLfMergeSettings.MongoHostname;
-					return _mongoHostname;
-				}
-			}
-		}
+		public string MongoHostname => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoHostname) ?? DefaultLfMergeSettings.MongoHostname;
 
 		public int MongoPort {
 			get {
-				if (_mongoPort != 0) return _mongoPort;
-				else {
 					string mongoPortStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort);
 					if (mongoPortStr == null) mongoPortStr = "";
-					if (Int32.TryParse(mongoPortStr, out _mongoPort)) {
-						return _mongoPort;
+					if (Int32.TryParse(mongoPortStr, out int mongoPort)) {
+						return mongoPort;
 					} else {
-						_mongoPort = DefaultLfMergeSettings.MongoPort;
-						return _mongoPort;
+						return DefaultLfMergeSettings.MongoPort;
 					}
-				}
 			}
 		}
 
-		public string MongoMainDatabaseName {
-			get {
-				if (_mongoMainDatabaseName != null) return _mongoMainDatabaseName;
-				else {
-					_mongoMainDatabaseName = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoMainDatabaseName) ?? DefaultLfMergeSettings.MongoMainDatabaseName;
-					return _mongoMainDatabaseName;
-				}
-			}
-		}
+		public string MongoMainDatabaseName => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoMainDatabaseName) ?? DefaultLfMergeSettings.MongoMainDatabaseName;
 
 		/// <summary>
 		/// The prefix prepended to project codes to get the Mongo database name.
 		/// </summary>
-		public string MongoDatabaseNamePrefix {
-			get {
-				if (_mongoDatabaseNamePrefix != null) return _mongoDatabaseNamePrefix;
-				else {
-					_mongoDatabaseNamePrefix = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoDatabaseNamePrefix) ?? DefaultLfMergeSettings.MongoDatabaseNamePrefix;
-					return _mongoDatabaseNamePrefix;
-				}
-			}
-		}
+		public string MongoDatabaseNamePrefix => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoDatabaseNamePrefix) ?? DefaultLfMergeSettings.MongoDatabaseNamePrefix;
 
 		public bool VerboseProgress {
 			get {
-				if (_verboseProgressStr != null) return _verboseProgress;
-				else {
-					_verboseProgressStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_VerboseProgress);
-					if (_verboseProgressStr == null) _verboseProgressStr = "";
-					_verboseProgress = LanguageForge.Model.ParseBoolean.FromString(_verboseProgressStr);
-					return _verboseProgress;
-				}
+					string verboseProgressStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_VerboseProgress);
+					if (verboseProgressStr == null) verboseProgressStr = "";
+					return LanguageForge.Model.ParseBoolean.FromString(verboseProgressStr);
 			}
 		}
 
-		public string LanguageDepotRepoUri {
-			get {
-				if (_languageDepotRepoUri != null) return _languageDepotRepoUri;
-				else {
-					_languageDepotRepoUri = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_LanguageDepotRepoUri) ?? DefaultLfMergeSettings.LanguageDepotRepoUri;
-					return _languageDepotRepoUri;
-				}
-			}
-		}
+		public string LanguageDepotRepoUri => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_LanguageDepotRepoUri) ?? DefaultLfMergeSettings.LanguageDepotRepoUri;
 
 		// Settings calculated at runtime from sources other than environment variables
 
@@ -153,7 +88,7 @@ namespace LfMerge.Core.Settings
 			Queue.CreateQueueDirectories(this);
 		}
 
-		private void SetAllMembers()
+		protected void SetAllMembers()
 		{
 			LcmDirectorySettings.SetProjectsDirectory(WebworkDir);
 			LcmDirectorySettings.SetTemplateDirectory(TemplatesDir);


### PR DESCRIPTION
Unit tests were failing after switching the LfMerge build to a Dockerized environment. This PR gets them working again, at least on the FW 9 branch. (A separate PR will be needed for the FW 8 branch, of course).

The main change we had to account for was the change to LfMergeSettings and how it now takes environment variables as settings. The LfMergeSettings test doubles now set the vars they need before calling SetAllMembers().

**NOTE:** This PR does **not** run unit tests by default in the build, because they take too long (20+ minutes) to be useful. Instead, I intend to create another PR that divides the tests up into fast and slow tests, then runs the fast tests with every PR and allows us to run the slow tests on-demand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/240)
<!-- Reviewable:end -->
