### PR TITLE
Fix build of FW 8 versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Collect tarball images
       # Now should collect tarballs
-        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/repo/tarball ./
+        run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/tarball ./
 
       - uses: actions/upload-artifact@v2.2.4
         with:

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -19,6 +19,8 @@ cd "${REPO_ROOT}"
 "$SCRIPT_DIR"/setup-workspace.sh "${HOME}/packages/lfmerge"
 
 echo After setup-workspace.sh, pwd is $(pwd)
+echo cd to "${HOME}/packages/lfmerge"
+cd "${HOME}/packages/lfmerge"
 
 "$SCRIPT_DIR"/gitversion-combined.sh ${DbVersion}
 

--- a/docker/scripts/compile-lfmerge-combined.sh
+++ b/docker/scripts/compile-lfmerge-combined.sh
@@ -6,6 +6,7 @@ echo "Using $(which mono)"
 export FrameworkPathOverride=/opt/mono5-sil/lib/mono/4.5
 
 export DbVersion="${1-7000072}"
+echo "Building for ${DbVersion}"
 if [ "x$1" = "x7000072" ]; then
 /opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
 # dotnet build /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -31,8 +31,8 @@ EOF
 
 # Install binaries
 install -d ${DBDESTDIR}/${LIB}
-install -m 644 output/${BUILD}/${FRAMEWORK}/*.* ${DBDESTDIR}/${LIB}
-install -m 755 output/${BUILD}/${FRAMEWORK}/chorusmerge ${DBDESTDIR}/${LIB}
+install -m 644 output/${BUILD}/${FRAMEWORK}/*.* ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 644 output/${BUILD}/*.* ${DBDESTDIR}/${LIB}
+install -m 755 output/${BUILD}/${FRAMEWORK}/chorusmerge ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/chorusmerge ${DBDESTDIR}/${LIB}
 install -d ${DBDESTDIR}/${LIB}/Mercurial
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/convert
@@ -69,7 +69,6 @@ install -m 755 lfmergeqm ${COMMONDESTDIR}/usr/bin
 install -m 755 startlfmerge ${DBDESTDIR}/${LIB}
 # Install conf file
 install -d ${COMMONDESTDIR}/etc/languageforge/conf
-install -m 644 debian/sendreceive.conf ${COMMONDESTDIR}/etc/languageforge/conf
 # Create working directories
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/state
 mkdir -p ${COMMONDESTDIR}/var/lib/languageforge/lexicon/sendreceive/webwork

--- a/pbuild.sh
+++ b/pbuild.sh
@@ -82,5 +82,5 @@ EOF
 mkdir -p tarball
 for f in 68 69 70 72; do
 # for f in 72; do
-    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/repo/tarball ./
+    docker container cp tmp-lfmerge-build-70000${f}:/home/builder/packages/lfmerge/tarball ./
 done


### PR DESCRIPTION
The FW 8 versions no longer build into output/Release/net462, but only
into output/Release. So we need to grab the build output from there.
I've kept the ability to get build output from output/Release/net462 as
well, just in case this configuration changes again in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/242)
<!-- Reviewable:end -->
