### PR TITLE
Slightly more logging

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -98,6 +98,7 @@ namespace LfMerge.Core
 			if (FwProject.AllowDataMigration)
 				argsBldr.Append(" --migrate");
 			startInfo.Arguments = argsBldr.ToString();
+			Logger.Notice("About to run ({0}) with args ({1})", startInfo.FileName, startInfo.Arguments);
 			startInfo.CreateNoWindow = true;
 			startInfo.ErrorDialog = false;
 			startInfo.UseShellExecute = false;


### PR DESCRIPTION
This PR exists mostly as a way to force another build, because the build of version 2.0.113 seems to have gone wrong. [The GHCR problem](https://www.githubstatus.com/incidents/v4ct6yp3lgzl) around the time that build was running [caused 7 failed runs](https://github.com/sillsdev/LfMerge/actions/runs/2383558629/attempts/7) of the `release` job, and the resulting LfMerge image after the eighth build seems to have some issues, as it produced the following logs:

```plaintext
May 25 13:21:19 e5fcd101131c LfMerge[72]: Starting LfMerge for model version '7000068'
May 25 13:21:21 e5fcd101131c LfMerge[238]: LfMerge  (database 7000070) starting with args: -p test-rmunn-04 --action Synchronize
```

Note that model version 68 was supposed to start, but the /usr/lib/lfmerge/7000068/startlfmerge script ended up starting model version 70 instead. I have not been able to reproduce the problem locally, so my tentative hypothesis is that rerunning the `release` job failed somehow, putting the wrong LfMerge version in the wrong directory somehow.

So this PR exists to make a minor change to the LfMerge code and therefore build a 2.0.114 version, which will hopefully resolve the issue. If 2.0.114 exhibits the same model version confusion that 2.0.113 did, then there's a problem with the code. If 2.0.114 is fine, then the problem was that the 2.0.113 build happened at the same time as a partial GHCR outage that won't happen again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/244)
<!-- Reviewable:end -->
