### PR TITLE
Fix DbVersion in FW9 build

### DIFF
--- a/docker/scripts/compile-lfmerge-combined.sh
+++ b/docker/scripts/compile-lfmerge-combined.sh
@@ -8,11 +8,11 @@ export FrameworkPathOverride=/opt/mono5-sil/lib/mono/4.5
 export DbVersion="${1-7000072}"
 echo "Building for ${DbVersion}"
 if [ "x$1" = "x7000072" ]; then
-/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
-# dotnet build /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
+/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
+# dotnet build /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
 else
-/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
+/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
 fi
 
 # ln -sf ../Mercurial output/
-# xbuild /t:TestOnly /v:detailed /property:Configuration=Release build/LfMerge.proj
+# xbuild /t:TestOnly /v:detailed /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj

--- a/src/FixFwData/FixFwData.csproj
+++ b/src/FixFwData/FixFwData.csproj
@@ -28,7 +28,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <DefinePlatformConstants Condition="'$(OS)'!='Windows_NT'">LINUX</DefinePlatformConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>DEBUG;TRACE;DBVERSION_7000072;</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
+++ b/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
@@ -25,7 +25,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     </AppendToReleaseNotesProperty>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <IsPackable>false</IsPackable>
-    <DefineConstants>TRACE;DEBUG;DBVERSION_7000072</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -26,7 +26,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <ChangelogFile>../../CHANGELOG.md</ChangelogFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>TRACE;DEBUG;DBVERSION_7000072</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/LfMerge.Tests/LfMerge.Tests.csproj
+++ b/src/LfMerge.Tests/LfMerge.Tests.csproj
@@ -26,7 +26,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>TRACE;DEBUG;DBVERSION_7000072</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LfMergeAuxTool/LfMergeAuxTool.csproj
+++ b/src/LfMergeAuxTool/LfMergeAuxTool.csproj
@@ -26,7 +26,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>TRACE;DEBUG;DBVERSION_7000072</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/LfMergeQueueManager/LfMergeQueueManager.csproj
+++ b/src/LfMergeQueueManager/LfMergeQueueManager.csproj
@@ -26,7 +26,8 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>TRACE;DEBUG;DBVERSION_7000072</DefineConstants>
+    <DatabaseVersion Condition="'$(DatabaseVersion)'==''">7000072</DatabaseVersion>
+    <DefineConstants>DEBUG;TRACE;DBVERSION_$(DatabaseVersion);</DefineConstants>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
DbVersion was always being set to 7000072, because I wasn't defining the DatabaseVersion property in the msbuild invocation and the .csproj files were always defaulting to 7000072. This was correct for the FW 9 build, but the FW 8 build was always defaulting to 7000070 and that was wrong for the 68 and 69 builds. Now set correctly throughout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/248)
<!-- Reviewable:end -->
