### PR TITLE
Fix DbVersion in FW8 build

### DIFF
--- a/docker/scripts/compile-lfmerge-combined.sh
+++ b/docker/scripts/compile-lfmerge-combined.sh
@@ -8,11 +8,11 @@ export FrameworkPathOverride=/opt/mono5-sil/lib/mono/4.5
 export DbVersion="${1-7000072}"
 echo "Building for ${DbVersion}"
 if [ "x$1" = "x7000072" ]; then
-/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
-# dotnet build /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
+/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
+# dotnet build /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
 else
-/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release build/LfMerge.proj
+/opt/mono5-sil/bin/msbuild /t:CompileOnly /v:quiet /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj
 fi
 
 # ln -sf ../Mercurial output/
-# xbuild /t:TestOnly /v:detailed /property:Configuration=Release build/LfMerge.proj
+# xbuild /t:TestOnly /v:detailed /property:Configuration=Release /property:DatabaseVersion=${DbVersion} build/LfMerge.proj


### PR DESCRIPTION
DbVersion was always being set to 7000070, because I wasn't defining the DatabaseVersion property in the msbuild invocation and the .csproj files were always defaulting to 7000070. Now set correctly throughout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/249)
<!-- Reviewable:end -->
