### PR TITLE
Compress build artifacts for faster upload

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -197,13 +197,15 @@ jobs:
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
       - name: Collect tarball images
-      # Now should collect tarballs
         run: docker container cp tmp-lfmerge-build-${{matrix.dbversion}}:/home/builder/packages/lfmerge/tarball ./
+
+      - name: Compress tarball images for faster uploads
+        run: time (tar cf - tarball | gzip -c9 > tarball.tar.gz)
 
       - uses: actions/upload-artifact@v2.2.4
         with:
-          name: lfmerge-tarball
-          path: tarball
+          name: lfmerge-tarball-${{matrix.dbversion}}
+          path: tarball.tar.gz
     outputs:
       MsBuildVersion: ${{ steps.output_version_number.outputs.VersionFor7000072 }}
       TagFor7000068: ${{ steps.output_version_number.outputs.TagFor7000068 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,20 +53,21 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@v2.0.10
       with:
-        name: lfmerge-tarball
-        path: tarball
+        # No name specified, so will download all artifacts
+        path: all-tarballs
 
-    - name: Ensure all parts of final tarball exist
-      # TODO: Should no longer be needed; verify, then remove
-      run: |
-        mkdir -p tarball/lfmerge-7000068 || true
-        mkdir -p tarball/lfmerge-7000069 || true
-        mkdir -p tarball/lfmerge-7000070 || true
-        mkdir -p tarball/lfmerge-7000072 || true
-        mkdir -p tarball/lfmerge || true
+    - name: Verify that download step worked
+      run: ls -lR all-tarballs
+
+    - name: Uncompress build artifacts
+      run: for f in all-tarballs/*/*.tar.gz; do gzip -cd "${f}" | tar xf -; done
+
+    - name: Verify that uncompress step worked
+      run: ls -lR tarball
 
     - name: Restore executable bits
       # GitHub artifacts system strips executable bits, so restore them here
+      # TODO: Now that we upload .tar.gz format, no longer needed since tar format preserves Unix permissions. Verify, then remove this section
       run: |
         chmod +x tarball/lfmerge*/usr/bin/lfmerge
         chmod +x tarball/lfmerge*/usr/bin/lfmergeqm


### PR DESCRIPTION
GitHub Actions runs much faster uploading a single large file than a hundred smaller files of the same total size. So each DbVersion should compress its files into a single tarball before uploading build artifacts; that ends up saving over a minute in the release workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/251)
<!-- Reviewable:end -->
