### PR TITLE
Clean up old TODO comments

### DIFF
--- a/src/LfMerge.Core/DataConverters/CanonicalSources/CanonicalOptionListSource.cs
+++ b/src/LfMerge.Core/DataConverters/CanonicalSources/CanonicalOptionListSource.cs
@@ -27,11 +27,6 @@ namespace LfMerge.Core.DataConverters.CanonicalSources
 
 		public static CanonicalOptionListSource Create(string listCode)
 		{
-			// TODO: Consider whether to make singletons, for the sake of not having to re-parse the resources.
-			// However, I suspect that it won't be necessary, as CanonicalOptionListSource instances get attached
-			// to ConvertMongoToLcmOptionList instances, and those instances stick around for one entire Lexicon conversion.
-			// It appears to take 200ms to process semantic domains, and 30ms to process grammatical info. So it might
-			// not be worth the extra complexity of singletons -- or it might. That remains to be decided.
 			if (listCode == MagicStrings.LfOptionListCodeForGrammaticalInfo)
 				return new CanonicalPartOfSpeechSource();
 			else if (listCode == MagicStrings.LfOptionListCodeForSemanticDomains)

--- a/src/LfMerge.Core/DataConverters/CanonicalSources/CanonicalSemanticDomainItem.cs
+++ b/src/LfMerge.Core/DataConverters/CanonicalSources/CanonicalSemanticDomainItem.cs
@@ -192,9 +192,6 @@ namespace LfMerge.Core.DataConverters.CanonicalSources
 				int i = 0;
 				foreach (SemDomQuestion qStruct in questionsByWs[ws])
 				{
-					// TODO: Find out what set_String() would do with a null value. Would it remove the string?
-					// If it would *remove* it, then we might be able to replace string.Empty with nulls in the code below
-					// Right now, just be extra-cautious and ensure we never put nulls into set_String().
 					semdom.QuestionsOS[i].Question.set_String(wsId, qStruct.Question ?? string.Empty);
 					semdom.QuestionsOS[i].ExampleSentences.set_String(wsId, qStruct.ExampleSentences ?? string.Empty);
 					semdom.QuestionsOS[i].ExampleWords.set_String(wsId, qStruct.ExampleWords ?? string.Empty);

--- a/src/LfMerge.Core/LanguageForge/Config/LfFieldTypeMapper.cs
+++ b/src/LfMerge.Core/LanguageForge/Config/LfFieldTypeMapper.cs
@@ -4,8 +4,6 @@ using System;
 
 namespace LfMerge.Core.LanguageForge.Config
 {
-	// TODO: Is this extra layer of indirection really benefitting us? Maybe MongoRegistrar should
-	// take a BidirectionalDictionary instead of an LfFieldTypeMapper.
 	public class LfFieldTypeMapper
 	{
 		public BidirectionalDictionary<string, Type> Map { get; private set; }

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -148,7 +148,6 @@ namespace LfMerge.Core.MongoConnector
 			IMongoCollection<BsonDocument> lexicon = db.GetCollection<BsonDocument>(MagicStrings.LfCollectionNameForLexicon);
 			var filter = new BsonDocument();
 			filter.Add("guid", new BsonDocument("$ne", BsonNull.Value));
-			// TODO: Get this out of AuthorInfo.ModifiedDate instead! We want to compare LCM DateModified to previous LCM DateModified.
 			filter.Add("authorInfo.modifiedDate", new BsonDocument("$ne", BsonNull.Value));
 			var projection = new BsonDocument();
 			projection.Add("guid", 1);

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -484,28 +484,6 @@ namespace LfMerge.Core.MongoConnector
 			var result = collection.BulkWrite(updates, options);
 		}
 
-		// public void OldVersionOfSetCommentReplyGuids(ILfProject project, IDictionary<string,string> uniqIdToGuidMappings)
-		// {
-		// 	if (uniqIdToGuidMappings == null || uniqIdToGuidMappings.Count <= 0)
-		// 	{
-		// 		// Nothing to do! And BulkWrite *requires* at least one update, otherwise Mongo will throw an
-		// 		// error. So it would cause an error to proceed if there are no uniqid -> GUID mappings to write.
-		// 		return;
-		// 	}
-		// 	IMongoDatabase db = GetProjectDatabase(project);
-		// 	IMongoCollection<BsonDocument> collection = db.GetCollection<BsonDocument>(MagicStrings.LfCollectionNameForLexiconComments);
-		// 	var updates = new List<UpdateOneModel<BsonDocument>>(uniqIdToGuidMappings.Count);
-		// 	foreach (KeyValuePair<string, string> kv in uniqIdToGuidMappings)
-		// 	{
-		// 		string uniqid = kv.Key;
-		// 		string guid = kv.Value;
-		// 		UpdateOneModel<BsonDocument> update = PrepareUpdateCommentReplyGuidForUniqId(uniqid, guid);
-		// 		updates.Add(update);
-		// 	}
-		// 	var options = new BulkWriteOptions { IsOrdered = false };
-		// 	var result = collection.BulkWrite(updates, options);
-		// }
-
 		public Dictionary<string, LfInputSystemRecord> GetInputSystems(ILfProject project)
 		{
 			MongoProjectRecord projectRecord = GetProjectRecord(project);

--- a/src/LfMerge.Core/ProcessingState.cs
+++ b/src/LfMerge.Core/ProcessingState.cs
@@ -265,7 +265,6 @@ namespace LfMerge.Core
 				if (File.Exists(fileName))
 				{
 					var json = File.ReadAllText(fileName);
-					// TODO: Use http://stackoverflow.com/a/8312048/2314532 instead of this hack
 					try
 					{
 						ProcessingState state = JsonConvert.DeserializeObject<ProcessingState>(json);


### PR DESCRIPTION
Simple PR that makes no code changes, just removes some TODO comments that are either already done, or that we have decided not to do after all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/252)
<!-- Reviewable:end -->
