### PR TITLE
Rename LD_TRUST_TOKEN env var

### DIFF
--- a/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
+++ b/src/LfMerge.Core/Actions/Infrastructure/ChorusHelper.cs
@@ -13,7 +13,7 @@ namespace LfMerge.Core.Actions.Infrastructure
 		static ChorusHelper()
 		{
 			Username = "x";
-			Password = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN") ?? "x";
+			Password = System.Environment.GetEnvironmentVariable("LANGUAGE_DEPOT_TRUST_TOKEN") ?? "x";
 		}
 
 		public virtual string GetSyncUri(ILfProject project)
@@ -24,7 +24,7 @@ namespace LfMerge.Core.Actions.Infrastructure
 
 			var uriBldr = new UriBuilder(project.LanguageDepotProjectUri) {
 				UserName = Username,
-				Password = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN") ?? Password,
+				Password = System.Environment.GetEnvironmentVariable("LANGUAGE_DEPOT_TRUST_TOKEN") ?? Password,
 				Path = HttpUtilityFromMono.UrlEncode(project.LanguageDepotProject.Identifier)
 			};
 			return uriBldr.Uri.ToString();

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -30,7 +30,7 @@ namespace LfMerge
 			// Username and Password will usually be "x" because it's dealt with on Language Forge site.
 			// However, when debugging LfMerge we want to be able to set it to a real name
 			ChorusHelper.Username = options.User;
-			ChorusHelper.Password = System.Environment.GetEnvironmentVariable("LD_TRUST_TOKEN") ?? options.Password;
+			ChorusHelper.Password = System.Environment.GetEnvironmentVariable("LANGUAGE_DEPOT_TRUST_TOKEN") ?? options.Password;
 
 			ExceptionLogging.Client.AddInfo(options.ProjectCode, MainClass.ModelVersion);
 

--- a/sudoers.d.lfmerge.conf
+++ b/sudoers.d.lfmerge.conf
@@ -1,1 +1,2 @@
 Defaults env_keep += "LFMERGE_*"
+Defaults env_keep += "LANGUAGE_DEPOT_*"


### PR DESCRIPTION
Environment variables for LfMerge cannot start with LD_ or they will get removed by sudo, so this needs to be renamed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/255)
<!-- Reviewable:end -->
