### PR TITLE
Wait for queue file to be closed, not opened

### DIFF
--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 # Run lfmergeqm every time a file is created in the sync queue
+# We use the close_write event because the create event can be fired before the file's contents are written, and then `lfmergeqm` can run too early
 
 # This is expected to run as the CMD, launched by the entry point.
 
-while inotifywait -e create /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
+while inotifywait -e close_write /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
   sudo -u www-data lfmergeqm
 done


### PR DESCRIPTION
Running the queue manager when a file is created in the directory is sometimes triggering too early, because we're writing to these files via `echo "projectCode: something" | sudo tee syncqueue/something`. But programs like `tee` have a three-step process for writing to a file:

1. Open the file
2. Wait for contents from stdin, then write them out
3. When stdin closes, close the file

This means that by simply listening for the `create` event, we're sometimes triggering lfmergeqm to run between steps 1 and 2, and then the queue manager doesn't find any contents in the file in the queue directory, and exits again -- and then that project doesn't run the Send/Receive process until a different project triggers Send/Receive.

By waiting for the `close_write` event instead, we'll ensure that any files we are notified about will already have their contents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/256)
<!-- Reviewable:end -->
