### PR TITLE
Update AssemblyInfo.cs files in Docker build

### DIFF
--- a/docker/scripts/gitversion-combined.sh
+++ b/docker/scripts/gitversion-combined.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+
 echo "Calculated versions:"
 echo "DebPackageVersion=${DebPackageVersion}"
 echo "MajorMinorPatch=${MajorMinorPatch}"
-echo "AssemblySemVer=${AssemblySemVer}"
-echo "AssemblySemFileVer=${AssemblySemFileVer}"
+echo "AssemblyVersion=${AssemblyVersion}"
+echo "FileVersion=${FileVersion}"
 echo "InformationalVersion=${InformationalVersion}"
 
 # Fetch tags for GitVersion
@@ -19,5 +21,11 @@ export MONO_PREFIX=/opt/mono5-sil
 RUNMODE="PACKAGEBUILD" BUILD=Release . environ
 msbuild /t:RestoreBuildTasks build/LfMerge.proj
 mkdir -p output/Release
+
+if [ -n "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -a "$UPDATE_ASSEMBLYINFO_BY_SCRIPT" -ne 0 ]; then
+	UPDATE_SCRIPT="${SCRIPT_DIR}/update-assemblyinfo.sh"
+	echo "Will run ${UPDATE_SCRIPT} to update AssemblyInfo.cs files"
+	[ -x "${UPDATE_SCRIPT}" ] && find src -name AssemblyInfo.cs -path '*LfMerge*' -print0 | xargs -0 -n 1 "${UPDATE_SCRIPT}"
+fi
 
 echo "Building packages for version ${DebPackageVersion}"


### PR DESCRIPTION
This will only run in FW 8 builds, because in FW 9 builds we use the .csproj properties instead. But it's worth having the code in all builds, so that the builds are consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/262)
<!-- Reviewable:end -->
