### PR TITLE
Exit build if any errors occur

### DIFF
--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
 
 export DbVersion="${1-7000072}"

--- a/docker/scripts/compile-lfmerge-combined.sh
+++ b/docker/scripts/compile-lfmerge-combined.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+
+set -e
+
 echo "Compiling LfMerge and running unit tests"
 BUILD=Release . environ
 

--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 

--- a/docker/scripts/download-dependencies-combined.sh
+++ b/docker/scripts/download-dependencies-combined.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+
+set -e
+
 echo "Downloading dependencies"
 export MONO_PREFIX=/opt/mono5-sil
 . environ

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DEST="${1:-${HOME}/packages/lfmerge}"
 
 export MONO_PREFIX=/opt/mono5-sil

--- a/docker/scripts/test-lfmerge-combined.sh
+++ b/docker/scripts/test-lfmerge-combined.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 export DbVersion="${1-7000072}"
 


### PR DESCRIPTION
We'll use `set -e` in all our build scripts, to make sure we had no
errors. That's an omission we should have rectified long ago.

Note that some people recommend `trap some_func ERR` instead, to call
`some_func` if any errors occur, which would allow recovery in some
circumstances. I'll use that it if turns out to be useful, but exiting
on error is the most helpful behavior most of the time in this build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/264)
<!-- Reviewable:end -->
