### PR TITLE
Update dotnet SDK and runtime images to 6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 ARG DbVersion=7000072
 
-FROM ghcr.io/sillsdev/lfmerge-base AS lfmerge-builder-base
+FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID

--- a/Dockerfile.builder-base
+++ b/Dockerfile.builder-base
@@ -1,0 +1,23 @@
+ARG DbVersion=7000072
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-builder-base
+WORKDIR /build/lfmerge
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+RUN apt-get update && apt-get install -y gnupg
+
+COPY sil-packages-key.gpg .
+COPY sil-packages-testing-key.gpg .
+RUN apt-key add sil-packages-key.gpg
+RUN apt-key add sil-packages-testing-key.gpg
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
+# Dependencies from Debian "control" file
+RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo && rm -rf /var/lib/apt/lists/*
+
+# Ensure fieldworks group exists in case lfmerge-fdo package didn't install it, and that www-data is part of that group
+# Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists
+RUN addgroup --system --quiet fieldworks ; \
+    adduser --quiet www-data fieldworks ; \
+	install -d -o www-data -g www-data -m 02775 /var/www/.local

--- a/Dockerfile.builder-base
+++ b/Dockerfile.builder-base
@@ -1,6 +1,6 @@
 ARG DbVersion=7000072
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS lfmerge-builder-base
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS lfmerge-builder-base
 WORKDIR /build/lfmerge
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 ARG DbVersion=7000072
 
-FROM ghcr.io/sillsdev/lfmerge-base
+FROM ghcr.io/sillsdev/lfmerge-base:runtime
 
 # install LFMerge prerequisites
 # python - required by Mercurial, which is bundled in the LFMerge installation

--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -1,0 +1,23 @@
+ARG DbVersion=7000072
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0 AS lfmerge-builder-base
+WORKDIR /build/lfmerge
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+RUN apt-get update && apt-get install -y gnupg
+
+COPY sil-packages-key.gpg .
+COPY sil-packages-testing-key.gpg .
+RUN apt-key add sil-packages-key.gpg
+RUN apt-key add sil-packages-testing-key.gpg
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic main' > /etc/apt/sources.list.d/llso-experimental.list
+RUN echo 'deb http://linux.lsdev.sil.org/ubuntu bionic-experimental main' >> /etc/apt/sources.list.d/llso-experimental.list
+# Dependencies from Debian "control" file
+RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-dev iputils-ping cpp python-dev pkg-config mono5-sil mono5-sil-msbuild libicu-dev lfmerge-fdo && rm -rf /var/lib/apt/lists/*
+
+# Ensure fieldworks group exists in case lfmerge-fdo package didn't install it, and that www-data is part of that group
+# Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists
+RUN addgroup --system --quiet fieldworks ; \
+    adduser --quiet www-data fieldworks ; \
+	install -d -o www-data -g www-data -m 02775 /var/www/.local

--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -1,6 +1,6 @@
 ARG DbVersion=7000072
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0 AS lfmerge-builder-base
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS lfmerge-builder-base
 WORKDIR /build/lfmerge
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This will change the base images, so will require a large download next time lfmerge is deployed. But that large download will only happen once, and this is the perfect time to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/267)
<!-- Reviewable:end -->
