### PR TITLE
Do not put projects on hold for DNS errors

### DIFF
--- a/src/LfMerge.Core/Actions/SynchronizeAction.cs
+++ b/src/LfMerge.Core/Actions/SynchronizeAction.cs
@@ -165,6 +165,15 @@ namespace LfMerge.Core.Actions
 					return;
 				}
 
+				// Re-queue projects if clone failed due to DNS errors, as those are likely to be transient
+				if (SyncResultedInError(project, syncResult,
+						"Temporary failure in name resolution",
+						ProcessingState.SendReceiveStates.CLONING))
+				{
+					LfMerge.Core.Queues.Queue.GetQueue(LfMerge.Core.Queues.QueueNames.Synchronize).EnqueueProject(project.ProjectCode);
+					return;
+				}
+
 				line = LfMergeBridgeServices.GetLineContaining(syncResult, "No changes from others");
 				if (!string.IsNullOrEmpty(line))
 				{


### PR DESCRIPTION
Fixes #268. DNS errors are likely transient, so don't put projects on hold if that happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/270)
<!-- Reviewable:end -->
