### PR TITLE
Try harder to avoid the lfmergeqm race condition

### DIFF
--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -7,4 +7,6 @@
 
 while inotifywait -e close_write /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
   sudo -u www-data lfmergeqm
+  # Run it again just to ensure that any initial clones that missed a race condition have a chance to get noticed
+  sudo -u www-data lfmergeqm
 done


### PR DESCRIPTION
Even with using the close_write event, we've sometimes observed the
queue appearing empty when the queue manager starts. So we simply run
the queue manager twice whenever the inotifywait event triggers. That
way anything missed on the first run should be caught by the second run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/272)
<!-- Reviewable:end -->
