### PR TITLE
Exit LfMerge container faster by handling SIGTERM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,10 @@ trap "exit" TERM
 # Ensure /var/log/syslog exists so tail -f /var/log/syslog will run
 logger "Starting container..."
 # echo /var/log/syslog to container stdout so it shows up in `kubectl logs`
+# First waiting for syslog to exist (race condition: `logger` can return before syslog file is created)
+until [ -r /var/log/syslog ]; do
+  sleep 0.2
+done
 tail -f /var/log/syslog &
 
 # run lfmergeqm on startup to clear out any failed send/receive sessions from previous container

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Catch SIGTERM and exit cleanly
+trap "exit" TERM
+
 # rsyslog needs to run so that lfmerge can log to /var/log/syslog
 /etc/init.d/rsyslog start
 

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Catch SIGTERM and exit cleanly
+trap "exit" TERM
+# This is also handled in entrypoint.sh, but since entrypoint.sh uses exec to run this script, we need to handle SIGTERM here as well
+
 # Run lfmergeqm every time a file is created in the sync queue
 # We use the close_write event because the create event can be fired before the file's contents are written, and then `lfmergeqm` can run too early
 


### PR DESCRIPTION
This will allow the container to shut down cleanly in docker-compose and Kubernetes, rather than waiting for 10 seconds when it doesn't answer SIGTERM and then eventually being sent SIGKILL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/273)
<!-- Reviewable:end -->
