### PR TITLE
Skip failing entries in sync, rather than putting projects on hold

### DIFF
--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -2,6 +2,7 @@
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using LfMerge.Core.DataConverters;
 using LfMerge.Core.FieldWorks;
 using LfMerge.Core.Logging;
@@ -64,8 +65,12 @@ namespace LfMerge.Core.Actions
 			Logger.Debug("TransferLcmToMongoAction: setting up lexicon converter");
 			_lexiconConverter = new ConvertLcmToMongoLexicon(project, Logger, _connection, Progress, _projectRecordFactory);
 			Logger.Debug("TransferLcmToMongoAction: about to run lexicon conversion");
-			var errors = _lexiconConverter.RunConversion();
+			var errorsCopy = _lexiconConverter.RunConversion().ToList();
 			//todo error handling
+			if (errorsCopy.Any())
+			{
+				
+			}
 
 			Logger.Debug("TransferLcmToMongoAction: successful transfer; setting last-synced date");
 			_connection.SetLastSyncedDate(project, DateTime.UtcNow);

--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -67,13 +67,13 @@ namespace LfMerge.Core.Actions
 			Logger.Debug("TransferLcmToMongoAction: about to run lexicon conversion");
 			var errorsCopy = _lexiconConverter.RunConversion();
 			if (errorsCopy.Any()) {
+				Logger.Warning($"TransferLcmToMongoAction: partial transfer, skipped {errorsCopy.EntryErrorCount} entries and {errorsCopy.CommentErrorCount} comments");
 				var report = errorsCopy.CreateReports();
-				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
+				project.State.ReportLcmToMongoErrors(report);
 			}
 
 			Logger.Debug("TransferLcmToMongoAction: successful transfer; setting last-synced date");
 			_connection.SetLastSyncedDate(project, DateTime.UtcNow);
-			// TODO: Return null since there were no errors
 		}
 
 		protected override ActionNames NextActionName

--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -65,15 +65,18 @@ namespace LfMerge.Core.Actions
 			Logger.Debug("TransferLcmToMongoAction: setting up lexicon converter");
 			_lexiconConverter = new ConvertLcmToMongoLexicon(project, Logger, _connection, Progress, _projectRecordFactory);
 			Logger.Debug("TransferLcmToMongoAction: about to run lexicon conversion");
-			var errorsCopy = _lexiconConverter.RunConversion().ToList();
-			//todo error handling
-			if (errorsCopy.Any())
+			var errorsCopy = _lexiconConverter.RunConversion();
+			var entryErrors = errorsCopy.Item1;
+			var commentErrors = errorsCopy.Item2;
+			if (entryErrors.Any() || commentErrors.Any())
 			{
-				
+				var errorReport = Reporting.ConversionErrors.Create(entryErrors, commentErrors);
+				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
 			}
 
 			Logger.Debug("TransferLcmToMongoAction: successful transfer; setting last-synced date");
 			_connection.SetLastSyncedDate(project, DateTime.UtcNow);
+			// TODO: Return null since there were no errors
 		}
 
 		protected override ActionNames NextActionName

--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2016-2018 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
+using System.Collections.Generic;
 using LfMerge.Core.DataConverters;
 using LfMerge.Core.FieldWorks;
 using LfMerge.Core.Logging;
@@ -63,7 +64,8 @@ namespace LfMerge.Core.Actions
 			Logger.Debug("TransferLcmToMongoAction: setting up lexicon converter");
 			_lexiconConverter = new ConvertLcmToMongoLexicon(project, Logger, _connection, Progress, _projectRecordFactory);
 			Logger.Debug("TransferLcmToMongoAction: about to run lexicon conversion");
-			_lexiconConverter.RunConversion();
+			var errors = _lexiconConverter.RunConversion();
+			//todo error handling
 
 			Logger.Debug("TransferLcmToMongoAction: successful transfer; setting last-synced date");
 			_connection.SetLastSyncedDate(project, DateTime.UtcNow);

--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -68,8 +68,7 @@ namespace LfMerge.Core.Actions
 			var errorsCopy = _lexiconConverter.RunConversion();
 			if (errorsCopy.Any()) {
 				Logger.Warning($"TransferLcmToMongoAction: partial transfer, skipped {errorsCopy.EntryErrorCount} entries and {errorsCopy.CommentErrorCount} comments");
-				var report = errorsCopy.CreateReports();
-				project.State.ReportLcmToMongoErrors(report);
+				project.State.ReportLcmToMongoErrors(errorsCopy);
 			}
 
 			Logger.Debug("TransferLcmToMongoAction: successful transfer; setting last-synced date");

--- a/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
+++ b/src/LfMerge.Core/Actions/TransferLcmToMongoAction.cs
@@ -66,11 +66,8 @@ namespace LfMerge.Core.Actions
 			_lexiconConverter = new ConvertLcmToMongoLexicon(project, Logger, _connection, Progress, _projectRecordFactory);
 			Logger.Debug("TransferLcmToMongoAction: about to run lexicon conversion");
 			var errorsCopy = _lexiconConverter.RunConversion();
-			var entryErrors = errorsCopy.Item1;
-			var commentErrors = errorsCopy.Item2;
-			if (entryErrors.Any() || commentErrors.Any())
-			{
-				var errorReport = Reporting.ConversionErrors.Create(entryErrors, commentErrors);
+			if (errorsCopy.Any()) {
+				var report = errorsCopy.CreateReports();
 				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
 			}
 

--- a/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
+++ b/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
@@ -75,8 +75,7 @@ namespace LfMerge.Core.Actions
 			var errorsCopy = converter.RunConversion();
 			if (errorsCopy.Any()) {
 				Logger.Warning($"TransferMongoToLcmAction: partial transfer, skipped {errorsCopy.EntryErrorCount} entries and {errorsCopy.CommentErrorCount} comments");
-				var report = errorsCopy.CreateReports();
-				project.State.ReportMongoToLcmErrors(report);
+				project.State.ReportMongoToLcmErrors(errorsCopy);
 			}
 		}
 

--- a/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
+++ b/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
@@ -73,11 +73,8 @@ namespace LfMerge.Core.Actions
 
 			var converter = new ConvertMongoToLcmLexicon(Settings, project, Logger, Progress, _connection, _projectRecord, EntryCounts);
 			var errorsCopy = converter.RunConversion();
-			var entryErrors = errorsCopy.Item1;
-			var commentErrors = errorsCopy.Item2;
-			if (entryErrors.Any() || commentErrors.Any())
-			{
-				var errorReport = Reporting.ConversionErrors.Create(entryErrors, commentErrors);
+			if (errorsCopy.Any()) {
+				var report = errorsCopy.CreateReports();
 				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
 			}
 		}

--- a/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
+++ b/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
@@ -6,6 +6,7 @@ using LfMerge.Core.LanguageForge.Config;
 using LfMerge.Core.MongoConnector;
 using LfMerge.Core.Reporting;
 using LfMerge.Core.Settings;
+using System.Linq;
 using SIL.LCModel;
 
 namespace LfMerge.Core.Actions
@@ -71,7 +72,14 @@ namespace LfMerge.Core.Actions
 			}
 
 			var converter = new ConvertMongoToLcmLexicon(Settings, project, Logger, Progress, _connection, _projectRecord, EntryCounts);
-			converter.RunConversion();
+			var errorsCopy = converter.RunConversion();
+			var entryErrors = errorsCopy.Item1;
+			var commentErrors = errorsCopy.Item2;
+			if (entryErrors.Any() || commentErrors.Any())
+			{
+				var errorReport = Reporting.ConversionErrors.Create(entryErrors, commentErrors);
+				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
+			}
 		}
 
 		protected override ActionNames NextActionName

--- a/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
+++ b/src/LfMerge.Core/Actions/TransferMongoToLcmAction.cs
@@ -74,8 +74,9 @@ namespace LfMerge.Core.Actions
 			var converter = new ConvertMongoToLcmLexicon(Settings, project, Logger, Progress, _connection, _projectRecord, EntryCounts);
 			var errorsCopy = converter.RunConversion();
 			if (errorsCopy.Any()) {
+				Logger.Warning($"TransferMongoToLcmAction: partial transfer, skipped {errorsCopy.EntryErrorCount} entries and {errorsCopy.CommentErrorCount} comments");
 				var report = errorsCopy.CreateReports();
-				// TODO: Do something with the error report. Log something appropriate, set last synced date, and return the error report, maybe.
+				project.State.ReportMongoToLcmErrors(report);
 			}
 		}
 

--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
@@ -40,6 +40,7 @@ namespace LfMerge.Core.DataConverters
 			LfProjectConfig config = _factory.Create(_project).Config;
 			FieldLists fieldConfigs = FieldListsForEntryAndSensesAndExamples(config);
 
+			var exceptions = new List<CommentConversionError<ILexEntry>>();
 			var fixedComments = new List<LfComment>(_conn.GetComments(_project));
 			string allCommentsJson = JsonConvert.SerializeObject(fixedComments);
 			// _logger.Debug("Doing Lcm->Mongo direction. The json for ALL comments from Mongo would be: {0}", allCommentsJson);
@@ -55,7 +56,6 @@ namespace LfMerge.Core.DataConverters
 				List<KeyValuePair<string, Tuple<string, string>>> statusChanges = JsonConvert.DeserializeObject<List<KeyValuePair<string, Tuple<string, string>>>>(newStatusChangesStr);
 
 				var entryErrorsByGuid = _entryConversionErrors.EntryErrors.ToDictionary(s => s.EntryGuid());
-				var exceptions = new List<CommentConversionError<ILexEntry>>();
 				foreach (LfComment comment in comments)
 				{
 					// LfMergeBridge only sets the Guid in comment.Regarding, and leaves it to the LfMerge side to set the rest of the fields meaningfully

--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
@@ -18,14 +18,16 @@ namespace LfMerge.Core.DataConverters
 	{
 		private IMongoConnection _conn;
 		private ILfProject _project;
+		private readonly IEnumerable<Tuple<ILexEntry, Exception>> _entryConversionErrors;
 		private ILogger _logger;
 		private IProgress _progress;
 		private FwServiceLocatorCache _servLoc;
 		private MongoProjectRecordFactory _factory;
-		public ConvertLcmToMongoComments(IMongoConnection conn, ILfProject proj, ILogger logger, IProgress progress, MongoProjectRecordFactory factory)
+		public ConvertLcmToMongoComments(IMongoConnection conn, ILfProject proj, IEnumerable<Tuple<ILexEntry, Exception>> entryConversionErrors, ILogger logger, IProgress progress, MongoProjectRecordFactory factory)
 		{
 			_conn = conn;
 			_project = proj;
+			_entryConversionErrors = entryConversionErrors;
 			_servLoc = proj.FieldWorksProject.ServiceLocator;
 			_logger = logger;
 			_progress = progress;

--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
@@ -70,7 +70,7 @@ namespace LfMerge.Core.DataConverters
 								comment.Regarding = FromTargetGuid(guid, fieldConfigs);
 							}
 							catch (Exception e)
-							{	
+							{
 								skippedComments.Add(Tuple.Create(comment, e));
 							}
 						}
@@ -88,10 +88,11 @@ namespace LfMerge.Core.DataConverters
 					// 	comment.StatusGuid
 					// 	);
 				}
-				var skippedCommentsMap = new HashSet<LfComment>(skippedComments.Select(s => s.Item1));
-				_conn.UpdateComments(_project, comments.Where(s => !skippedCommentsMap.Contains(s)).ToList());
-				_conn.UpdateReplies(_project, replies);
-				_conn.UpdateCommentStatuses(_project, statusChanges);
+				var skippedCommentGuids = new HashSet<Nullable<Guid>>(skippedComments.Select(s => s.Item1.Guid));
+				var skippedCommentGuidStrs = new HashSet<string>(skippedCommentGuids.Select(s => s.HasValue ? s.Value.ToString() : ""));
+				_conn.UpdateComments(_project, comments.Where(s => !skippedCommentGuids.Contains(s.Guid)).ToList());
+				_conn.UpdateReplies(_project, replies.Where(s => !skippedCommentGuidStrs.Contains(s.Item1)).ToList());
+				_conn.UpdateCommentStatuses(_project, statusChanges.Where(s => !skippedCommentGuidStrs.Contains(s.Key)).ToList());
 			}
 			else
 			{

--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoComments.cs
@@ -34,7 +34,7 @@ namespace LfMerge.Core.DataConverters
 			_factory = factory;
 		}
 
-		public void RunConversion()
+		public List<Tuple<LfComment, Exception>> RunConversion()
 		{
 			var skippedEntryGuids = new HashSet<Guid>(_entryConversionErrors.Select(s => s.Item1.Guid));
 			var skippedComments = new List<Tuple<LfComment, Exception>>();
@@ -98,6 +98,7 @@ namespace LfMerge.Core.DataConverters
 			{
 				// Failure, which has already been logged so we don't need to log it again
 			}
+			return skippedComments;
 		}
 
 		public struct FieldLists

--- a/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertLcmToMongoLexicon.cs
@@ -142,8 +142,6 @@ namespace LfMerge.Core.DataConverters
 				catch (Exception e)
 				{
 					exceptions.AddEntryError(LcmEntry, e);
-
-					//todo check if all entries have been failures
 				}
 				finally
 				{

--- a/src/LfMerge.Core/DataConverters/ConvertMongoToLcmComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertMongoToLcmComments.cs
@@ -17,13 +17,15 @@ namespace LfMerge.Core.DataConverters
 	{
 		private IMongoConnection _conn;
 		private ILfProject _project;
+		private List<Tuple<LfLexEntry, Exception>> _entryConversionErrors;
 		private ILogger _logger;
 		private IProgress _progress;
 
-		public ConvertMongoToLcmComments(IMongoConnection conn, ILfProject proj, ILogger logger, IProgress progress)
+		public ConvertMongoToLcmComments(IMongoConnection conn, ILfProject proj, List<Tuple<LfLexEntry, Exception>> entryConversionErrors, ILogger logger, IProgress progress)
 		{
 			_conn = conn;
 			_project = proj;
+			_entryConversionErrors = entryConversionErrors;
 			_logger = logger;
 			_progress = progress;
 		}

--- a/src/LfMerge.Core/DataConverters/ConvertMongoToLcmComments.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertMongoToLcmComments.cs
@@ -84,9 +84,9 @@ namespace LfMerge.Core.DataConverters
 				}
 			}
 			var skippedCommentGuids = new HashSet<string>(exceptions.Select(s => s.CommentGuid().ToString()));
-			string allCommentsJson = JsonConvert.SerializeObject(commentsWithIds.Where(s => !skippedCommentGuids.Contains(s.Key)));
+			string unskippedCommentsJson = JsonConvert.SerializeObject(commentsWithIds.Where(s => !skippedCommentGuids.Contains(s.Key)));
 			string bridgeOutput;
-			CallLfMergeBridge(allCommentsJson, out bridgeOutput);
+			CallLfMergeBridge(unskippedCommentsJson, out bridgeOutput);
 			// LfMergeBridge returns two lists of IDs (comment IDs or reply IDs) that need to have their GUIDs updated in Mongo.
 			string commentGuidMappingsStr = GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New comment ID->Guid mappings: ");
 			string replyGuidMappingsStr = GetPrefixedStringFromLfMergeBridgeOutput(bridgeOutput, "New reply ID->Guid mappings: ");

--- a/src/LfMerge.Core/DataConverters/ConvertMongoToLcmLexicon.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertMongoToLcmLexicon.cs
@@ -125,7 +125,7 @@ namespace LfMerge.Core.DataConverters
 		}
 		#endif
 
-		public void RunConversion()
+		public Tuple<List<Tuple<LfLexEntry, Exception>>, List<Tuple<LfComment, Exception, LfLexEntry, Exception>>> RunConversion()
 		{
 			var exceptions = new List<Tuple<LfLexEntry, Exception>>();
 			Logger.Notice("MongoToLcm: Converting lexicon for project {0}", LfProject.ProjectCode);
@@ -150,7 +150,7 @@ namespace LfMerge.Core.DataConverters
 						converter.UpdateLcmOptionListFromLf(ProjectRecord.InterfaceLanguageCode);
 					}
 					#endif
-					
+
 					foreach (LfLexEntry lfEntry in lexicon)
 					{
 						try
@@ -165,9 +165,10 @@ namespace LfMerge.Core.DataConverters
 				});
 			// Comment conversion gets run AFTER lexicon conversion, so that any comments on new entries are handled correctly in FW
 			var commCvtr = new ConvertMongoToLcmComments(Connection, LfProject, exceptions, Logger, Progress);
-			commCvtr.RunConversion(entryObjectIdToGuidMappings);
+			var skippedComments = commCvtr.RunConversion(entryObjectIdToGuidMappings);
 			if (Settings.CommitWhenDone)
 				Cache.ActionHandlerAccessor.Commit();
+			return Tuple.Create(exceptions, skippedComments);
 		}
 
 		// Shorthand for getting an instance from the cache's service locator

--- a/src/LfMerge.Core/DataConverters/ConvertUtilities.cs
+++ b/src/LfMerge.Core/DataConverters/ConvertUtilities.cs
@@ -54,6 +54,20 @@ namespace LfMerge.Core.DataConverters
 		}
 
 		/// <summary>
+		/// Return a name suitable for logging from an entry
+		/// </summary>
+		/// <returns>The lexeme(s), if present, otherwise something suitable.</returns>
+		/// <param name="lcmEntry">LCM entry we want to write about in the log.</param>
+		public static string EntryNameForDebugging(ILexEntry lcmEntry)
+		{
+			if (lcmEntry == null)
+				return "<null entry>";
+			string citationForm = lcmEntry.CitationForm?.BestVernacularAnalysisAlternative?.Text;
+			string lexeme = lcmEntry.LexemeFormOA?.Form?.BestVernacularAnalysisAlternative?.Text;
+			return citationForm ?? lexeme ?? "<null lexeme>";
+		}
+
+		/// <summary>
 		/// Turn a custom StText field into a BsonDocument suitable for storing in Mongo. Returns
 		/// </summary>
 		/// <returns>A BsonDocument with the following structure:

--- a/src/LfMerge.Core/ProcessingState.cs
+++ b/src/LfMerge.Core/ProcessingState.cs
@@ -112,40 +112,14 @@ namespace LfMerge.Core
 			SetErrorState(SendReceiveStates.HOLD, ErrorCodes.Unspecified, errorMessage, args);
 		}
 
-		public void ReportMongoToLcmErrors(ConversionErrors toLcmErrors, Exception overallException = null)
+		public void ReportMongoToLcmErrors(ConversionError<LanguageForge.Model.LfLexEntry> toLcmErrors)
 		{
-			if (_error != null && _error.Skipped != null) {
-				_error.Skipped.ToLcm = toLcmErrors;
-				_error.Timestamp = DateTime.UtcNow;
-			} else {
-				var skipped = ConversionErrorReport.Create(null, toLcmErrors);
-				if (_error != null) {
-					_error.Skipped = skipped;
-					_error.ExceptionMessage = overallException?.ToString();
-					_error.Timestamp = DateTime.UtcNow;
-				} else {
-					_error = ErrorReport.Create(skipped, overallException);
-				}
-			}
-			Error = _error;  // Trigger SetProperty() so the error is serialized
+			Error = ErrorReport.WithLcmErrors(Error, toLcmErrors);
 		}
 
-		public void ReportLcmToMongoErrors(ConversionErrors toMongoErrors, Exception overallException = null)
+		public void ReportLcmToMongoErrors(ConversionError<SIL.LCModel.ILexEntry> toMongoErrors)
 		{
-			if (_error != null && _error.Skipped != null) {
-				_error.Skipped.ToMongo = toMongoErrors;
-				_error.Timestamp = DateTime.UtcNow;
-			} else {
-				var skipped = ConversionErrorReport.Create(toMongoErrors, null);
-				if (_error != null) {
-					_error.Skipped = skipped;
-					_error.ExceptionMessage = overallException?.ToString();
-					_error.Timestamp = DateTime.UtcNow;
-				} else {
-					_error = ErrorReport.Create(skipped, overallException);
-				}
-			}
-			Error = _error;  // Trigger SetProperty() so the error is serialized
+			Error = ErrorReport.WithMongoErrors(Error, toMongoErrors);
 		}
 
 		public void SetErrorState(SendReceiveStates state, ErrorCodes errorCode, string errorMessage, params object[] args)

--- a/src/LfMerge.Core/ProcessingState.cs
+++ b/src/LfMerge.Core/ProcessingState.cs
@@ -121,6 +121,7 @@ namespace LfMerge.Core
 				var skipped = ConversionErrorReport.Create(null, toLcmErrors);
 				if (_error != null) {
 					_error.Skipped = skipped;
+					_error.ExceptionMessage = overallException?.ToString();
 					_error.Timestamp = DateTime.UtcNow;
 				} else {
 					_error = ErrorReport.Create(skipped, overallException);
@@ -138,6 +139,7 @@ namespace LfMerge.Core
 				var skipped = ConversionErrorReport.Create(toMongoErrors, null);
 				if (_error != null) {
 					_error.Skipped = skipped;
+					_error.ExceptionMessage = overallException?.ToString();
 					_error.Timestamp = DateTime.UtcNow;
 				} else {
 					_error = ErrorReport.Create(skipped, overallException);

--- a/src/LfMerge.Core/ProcessingState.cs
+++ b/src/LfMerge.Core/ProcessingState.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) 2011-2016 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Autofac;
+using LfMerge.Core.Reporting;
 using LfMerge.Core.Settings;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -81,12 +83,14 @@ namespace LfMerge.Core
 		private string _errorMessage;
 		private int _errorCode;
 		private long _previousRunTotalMilliseconds;
+		private IList<ErrorReport> _errors;
 
 		protected ProcessingState()
 		{
 			_state = SendReceiveStates.CLONING;
 			_lastStateChangeTicks = DateTime.UtcNow.Ticks;
 			ProjectCode = string.Empty;
+			_errors = new List<ErrorReport>();
 		}
 
 		public ProcessingState(string projectCode, LfMergeSettings settings): this()
@@ -180,6 +184,11 @@ namespace LfMerge.Core
 		{
 			get { return _uncommittedEditCounter; }
 			set { SetProperty(ref _uncommittedEditCounter, value); }
+		}
+		public IList<ErrorReport> Errors
+		{
+			get { return _errors; }
+			set { SetProperty(ref _errors, value); }
 		}
 		public string ErrorMessage
 		{

--- a/src/LfMerge.Core/Reporting/ConversionError.cs
+++ b/src/LfMerge.Core/Reporting/ConversionError.cs
@@ -44,16 +44,6 @@ namespace LfMerge.Core.Reporting
 		public void AddCommentErrors(List<CommentConversionError<TEntry>> commentErrors) {
 			CommentErrors.AddRange(commentErrors);
 		}
-
-		public ConversionErrors CreateReports() {
-			var entryReports = EntryErrors.Select(e => e.CreateReport());
-			var commentReports = CommentErrors.Select(c => c.CreateReport());
-
-			return new ConversionErrors {
-				Entries = new ErrorList { List = entryReports.ToList() },
-				Comments = new ErrorList { List = commentReports.ToList() },
-			};
-		}
 	}
 
 	public class EntryConversionError<TEntry>
@@ -90,16 +80,6 @@ namespace LfMerge.Core.Reporting
 			ILexEntry lcmEntry = Entry as ILexEntry;
 			if (lcmEntry != null) return ConvertUtilities.EntryNameForDebugging(lcmEntry);
 			return string.Empty;
-		}
-
-		public SingleItemReport CreateReport() {
-			return new SingleItemReport {
-                Guid = EntryGuid(),
-                Id = MongoId(),
-                ExceptionMessage = Error.ToString(),
-                Label = Label(),
-                Entry = null  // This field is only used in comments
-            };
 		}
 	}
 
@@ -139,16 +119,6 @@ namespace LfMerge.Core.Reporting
 		public string Label() {
 			if (Comment == null || Comment.Content == null) return string.Empty;
 			return Comment.Content.Substring(0, 100);
-		}
-
-		public SingleItemReport CreateReport() {
-			return new SingleItemReport {
-                Guid = EntryGuid(),
-                Id = MongoId(),
-                ExceptionMessage = Error.ToString(),
-                Label = Label(),
-                Entry = EntryError?.CreateReport()
-            };
 		}
 	}
 }

--- a/src/LfMerge.Core/Reporting/ConversionError.cs
+++ b/src/LfMerge.Core/Reporting/ConversionError.cs
@@ -24,6 +24,10 @@ namespace LfMerge.Core.Reporting
 			return EntryErrors.Any() || CommentErrors.Any();
 		}
 
+		public int EntryErrorCount { get { return EntryErrors.Count; } }
+		public int CommentErrorCount { get { return CommentErrors.Count; } }
+		public int Count { get { return EntryErrorCount + CommentErrorCount; } }
+
 		public void AddEntryError(TEntry entry, Exception error) {
 			EntryErrors.Add(new EntryConversionError<TEntry>(entry, error));
 		}

--- a/src/LfMerge.Core/Reporting/ConversionError.cs
+++ b/src/LfMerge.Core/Reporting/ConversionError.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2022 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LfMerge.Core.LanguageForge.Model;
+using SIL.LCModel;
+using LfMerge.Core.DataConverters;
+
+namespace LfMerge.Core.Reporting
+{
+	public class ConversionError<TEntry>
+	{
+		public List<EntryConversionError<TEntry>> EntryErrors { get; set; }
+		public List<CommentConversionError<TEntry>> CommentErrors { get; set; }
+
+		public ConversionError() {
+			EntryErrors = new List<EntryConversionError<TEntry>>();
+			CommentErrors = new List<CommentConversionError<TEntry>>();
+		}
+
+		public bool Any() {
+			return EntryErrors.Any() || CommentErrors.Any();
+		}
+
+		public void AddEntryError(TEntry entry, Exception error) {
+			EntryErrors.Add(new EntryConversionError<TEntry>(entry, error));
+		}
+
+		public void AddCommentError(LfComment comment, Exception error, EntryConversionError<TEntry> entryError ) {
+			CommentErrors.Add(new CommentConversionError<TEntry>(comment, error, entryError));
+		}
+
+		public void AddCommentError(LfComment comment, Exception error, TEntry entry) {
+			var entryError = new EntryConversionError<TEntry>(entry, null);
+			CommentErrors.Add(new CommentConversionError<TEntry>(comment, error, entryError));
+		}
+
+		public void AddCommentErrors(List<CommentConversionError<TEntry>> commentErrors) {
+			CommentErrors.AddRange(commentErrors);
+		}
+
+		public ConversionErrors CreateReports() {
+			var entryReports = EntryErrors.Select(e => e.CreateReport());
+			var commentReports = CommentErrors.Select(c => c.CreateReport());
+
+			return new ConversionErrors {
+				Entries = new ErrorList { List = entryReports.ToList() },
+				Comments = new ErrorList { List = commentReports.ToList() },
+			};
+		}
+	}
+
+	public class EntryConversionError<TEntry>
+	{
+		public TEntry Entry { get; set; }
+		public Exception Error { get; set; }
+
+		public EntryConversionError(TEntry entry, Exception error) {
+			Entry = entry;
+			Error = error;
+		}
+
+		public Guid EntryGuid() {
+			if (Entry == null) return Guid.Empty;
+			LfLexEntry lfEntry = Entry as LfLexEntry;
+			if (lfEntry != null) return lfEntry.Guid ?? Guid.Empty;
+			ILexEntry lcmEntry = Entry as ILexEntry;
+			if (lcmEntry != null) return lcmEntry.Guid;
+			return Guid.Empty;
+		}
+
+		public string MongoId() {
+			if (Entry == null) return null;
+			LfLexEntry lfEntry = Entry as LfLexEntry;
+			if (lfEntry != null && lfEntry.Id != null) return lfEntry.Id.ToString();
+			// No need to check ILexEntry as they don't have Mongo IDs
+			return null;
+		}
+
+		public string Label() {
+			if (Entry == null) return string.Empty;
+			LfLexEntry lfEntry = Entry as LfLexEntry;
+			if (lfEntry != null) return ConvertUtilities.EntryNameForDebugging(lfEntry);
+			ILexEntry lcmEntry = Entry as ILexEntry;
+			if (lcmEntry != null) return ConvertUtilities.EntryNameForDebugging(lcmEntry);
+			return string.Empty;
+		}
+
+		public SingleItemReport CreateReport() {
+			return new SingleItemReport {
+                Guid = EntryGuid(),
+                Id = MongoId(),
+                ExceptionMessage = Error.ToString(),
+                Label = Label(),
+                Entry = null  // This field is only used in comments
+            };
+		}
+	}
+
+	public class CommentConversionError<TEntry>
+	{
+		public LfComment Comment { get; set; }
+		public Exception Error { get; set; }
+		public EntryConversionError<TEntry> EntryError { get; set; }
+		public Guid OptionalEntryGuid { get; set; }
+
+		public CommentConversionError(LfComment comment, Exception error, EntryConversionError<TEntry> entryError, Guid entryGuid) {
+			Comment = comment;
+			Error = error;
+			EntryError = entryError;
+			OptionalEntryGuid = entryGuid;
+		}
+
+		public CommentConversionError(LfComment comment, Exception error, EntryConversionError<TEntry> entryError)
+			: this(comment, error, entryError, Guid.Empty) { }
+
+		public CommentConversionError(LfComment comment, Exception error, Guid entryGuid)
+			: this(comment, error, null, entryGuid) { }
+
+		public Guid EntryGuid() {
+			return EntryError?.EntryGuid() ?? Guid.Empty;
+		}
+
+		public Guid CommentGuid() {
+			return Comment?.Guid ?? Guid.Empty;
+		}
+
+		public string MongoId() {
+			if (Comment == null || Comment.Id == null) return null;
+			return Comment.Id.ToString();
+		}
+
+		public string Label() {
+			if (Comment == null || Comment.Content == null) return string.Empty;
+			return Comment.Content.Substring(0, 100);
+		}
+
+		public SingleItemReport CreateReport() {
+			return new SingleItemReport {
+                Guid = EntryGuid(),
+                Id = MongoId(),
+                ExceptionMessage = Error.ToString(),
+                Label = Label(),
+                Entry = EntryError?.CreateReport()
+            };
+		}
+	}
+}

--- a/src/LfMerge.Core/Reporting/ErrorReport.cs
+++ b/src/LfMerge.Core/Reporting/ErrorReport.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using LfMerge.Core.LanguageForge.Model;
+using SIL.LCModel;
 
 namespace LfMerge.Core.Reporting
 {
@@ -13,6 +16,20 @@ namespace LfMerge.Core.Reporting
         public string ExceptionMessage { get; set; }
 
         public ConversionErrorReport Skipped { get; set; }
+
+        public static ErrorReport Create(ConversionErrorReport skipped, Exception overallException)
+        {
+            return new ErrorReport {
+                Timestamp = DateTime.UtcNow,
+                ExceptionMessage = overallException?.ToString(),
+                Skipped = skipped
+            };
+        }
+
+        public static ErrorReport Create(ConversionErrorReport skipped)
+        {
+            return ErrorReport.Create(skipped, null);
+        }
     }
 
     public class ConversionErrorReport
@@ -20,18 +37,49 @@ namespace LfMerge.Core.Reporting
         public ConversionErrors ToMongo { get; set; }
         public ConversionErrors ToLcm { get; set; }
 
+        public static ConversionErrorReport Create(ConversionErrors toMongoErrors, ConversionErrors toLcmErrors)
+        {
+            return new ConversionErrorReport {
+                ToMongo = toMongoErrors,
+                ToLcm = toLcmErrors
+            };
+        }
     }
 
     public class ConversionErrors 
     {
         public ErrorList Entries { get; set; }
         public ErrorList Comments { get; set; }
+
+        public static ConversionErrors Create(
+            IEnumerable<Tuple<ILexEntry, Exception>> entryErrors,
+            IEnumerable<Tuple<LfComment, Exception, ILexEntry>> commentErrors)
+        {
+            return new ConversionErrors {
+                Entries = ErrorList.CreateEntryList(entryErrors),
+                Comments = ErrorList.CreateCommentList(commentErrors)
+            };
+        }
     }
 
     public class ErrorList
     {
         public int Count { get { return List?.Count ?? 0; } }
         public IList<SingleItemReport> List { get; set; }
+
+        public static ErrorList CreateEntryList(IEnumerable<Tuple<ILexEntry, Exception>> t)
+        {
+            return new ErrorList {
+                List = t.Select(SingleItemReport.CreateEntryReport).ToList()
+            };
+        }
+
+        public static ErrorList CreateCommentList(IEnumerable<Tuple<LfComment, Exception, ILexEntry>> t)
+        {
+            return new ErrorList {
+                List = t.Select(SingleItemReport.CreateCommentReport).ToList()
+            };
+        }
     }
 
 	public class SingleItemReport
@@ -42,9 +90,28 @@ namespace LfMerge.Core.Reporting
         public string Label { get; set; }
         public SingleItemReport Entry { get; set; }
 
-        public bool ShouldSerializeEntry()
+        public bool ShouldSerializeEntry() { return Entry != null; }
+
+        public static SingleItemReport CreateEntryReport(Tuple<ILexEntry, Exception> t)
         {
-            return Entry != null;
+            return new SingleItemReport {
+                Guid = t.Item1.Guid,
+                Id = null,
+                ExceptionMessage = t.Item2?.ToString(),
+                Label = "todo",
+                Entry = null
+            };
+        }
+
+        public static SingleItemReport CreateCommentReport(Tuple<LfComment, Exception, ILexEntry> t)
+        {
+            return new SingleItemReport {
+                Guid = t.Item1.Guid ?? Guid.Empty,
+                Id = t.Item1.Id.ToString(),
+                ExceptionMessage = t.Item2?.ToString(),
+                Label = "todo",
+                Entry = SingleItemReport.CreateEntryReport(Tuple.Create(t.Item3, (Exception)null))
+            };
         }
 	}
 }

--- a/src/LfMerge.Core/Reporting/ErrorReport.cs
+++ b/src/LfMerge.Core/Reporting/ErrorReport.cs
@@ -9,34 +9,34 @@ using SIL.LCModel;
 
 namespace LfMerge.Core.Reporting
 {
-    public class ErrorReport
-    {
-        public DateTime Timestamp { get; set; }
+	public class ErrorReport
+	{
+		public DateTime Timestamp { get; set; }
 
-        public string ExceptionMessage { get; set; }
+		public string ExceptionMessage { get; set; }
 
-        public ConversionErrorReport Skipped { get; set; }
+		public ConversionErrorReport Skipped { get; set; }
 
-        public static ErrorReport Create(ConversionErrorReport skipped, Exception overallException)
-        {
-            return new ErrorReport {
-                Timestamp = DateTime.UtcNow,
-                ExceptionMessage = overallException?.ToString(),
-                Skipped = skipped
-            };
-        }
+		public static ErrorReport Create(ConversionErrorReport skipped, Exception overallException)
+		{
+			return new ErrorReport {
+				Timestamp = DateTime.UtcNow,
+				ExceptionMessage = overallException?.ToString(),
+				Skipped = skipped
+			};
+		}
 
-        public ErrorReport WithSkipped(ConversionErrorReport skipped)
-        {
-            return new ErrorReport {
-                Timestamp = DateTime.UtcNow,
-                ExceptionMessage = ExceptionMessage,
-                Skipped = skipped
-            };
-        }
+		public ErrorReport WithSkipped(ConversionErrorReport skipped)
+		{
+			return new ErrorReport {
+				Timestamp = DateTime.UtcNow,
+				ExceptionMessage = ExceptionMessage,
+				Skipped = skipped
+			};
+		}
 
-        public static ErrorReport CreateOrUpdate(ErrorReport orig, ConversionErrorReport skipped)
-        {
+		public static ErrorReport CreateOrUpdate(ErrorReport orig, ConversionErrorReport skipped)
+		{
 			if (orig == null) {
 				return new ErrorReport {
 					Timestamp = DateTime.UtcNow,
@@ -50,70 +50,70 @@ namespace LfMerge.Core.Reporting
 					Skipped = skipped
 				};
 			}
-        }
+		}
 
-        public static ErrorReport WithMongoErrors(ErrorReport orig, ConversionError<ILexEntry> toMongoErrors)
-        {
+		public static ErrorReport WithMongoErrors(ErrorReport orig, ConversionError<ILexEntry> toMongoErrors)
+		{
 			var skipped = orig?.Skipped ?? ConversionErrorReport.FromMongoConversionError(toMongoErrors);
 			return ErrorReport.CreateOrUpdate(orig, skipped);
-        }
+		}
 
-        public static ErrorReport WithLcmErrors(ErrorReport orig, ConversionError<LfLexEntry> toLcmErrors)
-        {
+		public static ErrorReport WithLcmErrors(ErrorReport orig, ConversionError<LfLexEntry> toLcmErrors)
+		{
 			var skipped = orig?.Skipped ?? ConversionErrorReport.FromLcmConversionError(toLcmErrors);
 			return ErrorReport.CreateOrUpdate(orig, skipped);
-        }
-    }
+		}
+	}
 
-    public class ConversionErrorReport
-    {
-        public ConversionErrors ToMongo { get; set; }
-        public ConversionErrors ToLcm { get; set; }
+	public class ConversionErrorReport
+	{
+		public ConversionErrors ToMongo { get; set; }
+		public ConversionErrors ToLcm { get; set; }
 
-        public static ConversionErrorReport Create(ConversionErrors toMongoErrors, ConversionErrors toLcmErrors)
-        {
-            return new ConversionErrorReport {
-                ToMongo = toMongoErrors,
-                ToLcm = toLcmErrors
-            };
-        }
+		public static ConversionErrorReport Create(ConversionErrors toMongoErrors, ConversionErrors toLcmErrors)
+		{
+			return new ConversionErrorReport {
+				ToMongo = toMongoErrors,
+				ToLcm = toLcmErrors
+			};
+		}
 
-        public static ConversionErrorReport FromMongoConversionError<T>(ConversionError<T> mongoErrors)
-        {
-            return new ConversionErrorReport {
-                ToMongo = ConversionErrors.FromConversionError(mongoErrors),
+		public static ConversionErrorReport FromMongoConversionError<T>(ConversionError<T> mongoErrors)
+		{
+			return new ConversionErrorReport {
+				ToMongo = ConversionErrors.FromConversionError(mongoErrors),
 				ToLcm = null,
-            };
-        }
+			};
+		}
 
-        public static ConversionErrorReport FromLcmConversionError<T>(ConversionError<T> lcmErrors)
-        {
-            return new ConversionErrorReport {
-                ToMongo = null,
+		public static ConversionErrorReport FromLcmConversionError<T>(ConversionError<T> lcmErrors)
+		{
+			return new ConversionErrorReport {
+				ToMongo = null,
 				ToLcm = ConversionErrors.FromConversionError(lcmErrors),
-            };
-        }
-    }
+			};
+		}
+	}
 
-    public class ConversionErrors
-    {
-        public ErrorList Entries { get; set; }
-        public ErrorList Comments { get; set; }
+	public class ConversionErrors
+	{
+		public ErrorList Entries { get; set; }
+		public ErrorList Comments { get; set; }
 
-        public static ConversionErrors FromConversionError<T>(
+		public static ConversionErrors FromConversionError<T>(
 			ConversionError<T> errorSet)
-        {
-            return new ConversionErrors {
-                Entries = ErrorList.FromEntryErrors<T>(errorSet.EntryErrors),
+		{
+			return new ConversionErrors {
+				Entries = ErrorList.FromEntryErrors<T>(errorSet.EntryErrors),
 				Comments = ErrorList.FromCommentErrors<T>(errorSet.CommentErrors),
-            };
-        }
-    }
+			};
+		}
+	}
 
-    public class ErrorList
-    {
-        public int Count { get { return List?.Count ?? 0; } }
-        public IList<SingleItemReport> List { get; set; }
+	public class ErrorList
+	{
+		public int Count { get { return List?.Count ?? 0; } }
+		public IList<SingleItemReport> List { get; set; }
 
 		public static ErrorList FromEntryErrors<T>(List<EntryConversionError<T>> entryErrors)
 		{
@@ -128,17 +128,17 @@ namespace LfMerge.Core.Reporting
 				List = commentErrors.Select(SingleItemReport.FromCommentError<T>).ToList()
 			};
 		}
-    }
+	}
 
 	public class SingleItemReport
 	{
-        public Guid Guid { get; set; }
-        public string Id { get; set; }
-        public string ExceptionMessage { get; set; }
-        public string Label { get; set; }
-        public SingleItemReport Entry { get; set; }
+		public Guid Guid { get; set; }
+		public string Id { get; set; }
+		public string ExceptionMessage { get; set; }
+		public string Label { get; set; }
+		public SingleItemReport Entry { get; set; }
 
-        public bool ShouldSerializeEntry() { return Entry != null; }
+		public bool ShouldSerializeEntry() { return Entry != null; }
 
 		public static SingleItemReport FromEntryError<T>(EntryConversionError<T> error)
 		{

--- a/src/LfMerge.Core/Reporting/ErrorReport.cs
+++ b/src/LfMerge.Core/Reporting/ErrorReport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 SIL International
+// Copyright (c) 2022 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 
 using System;
@@ -46,7 +46,7 @@ namespace LfMerge.Core.Reporting
         }
     }
 
-    public class ConversionErrors 
+    public class ConversionErrors
     {
         public ErrorList Entries { get; set; }
         public ErrorList Comments { get; set; }
@@ -60,12 +60,29 @@ namespace LfMerge.Core.Reporting
                 Comments = ErrorList.CreateCommentList(commentErrors)
             };
         }
+
+        public static ConversionErrors Create(
+            IEnumerable<Tuple<LfLexEntry, Exception>> entryErrors,
+            IEnumerable<Tuple<LfComment, Exception, LfLexEntry, Exception>> commentErrors)
+        {
+            return new ConversionErrors {
+                Entries = ErrorList.CreateEntryList(entryErrors),
+                Comments = ErrorList.CreateCommentList(commentErrors)
+            };
+        }
     }
 
     public class ErrorList
     {
         public int Count { get { return List?.Count ?? 0; } }
         public IList<SingleItemReport> List { get; set; }
+
+        public static ErrorList CreateEntryList(IEnumerable<Tuple<LfLexEntry, Exception>> t)
+        {
+            return new ErrorList {
+                List = t.Select(SingleItemReport.CreateEntryReport).ToList()
+            };
+        }
 
         public static ErrorList CreateEntryList(IEnumerable<Tuple<ILexEntry, Exception>> t)
         {
@@ -74,6 +91,12 @@ namespace LfMerge.Core.Reporting
             };
         }
 
+        public static ErrorList CreateCommentList(IEnumerable<Tuple<LfComment, Exception, LfLexEntry, Exception>> t)
+        {
+            return new ErrorList {
+                List = t.Select(SingleItemReport.CreateCommentReport).ToList()
+            };
+        }
         public static ErrorList CreateCommentList(IEnumerable<Tuple<LfComment, Exception, ILexEntry>> t)
         {
             return new ErrorList {
@@ -92,14 +115,36 @@ namespace LfMerge.Core.Reporting
 
         public bool ShouldSerializeEntry() { return Entry != null; }
 
+        public static SingleItemReport CreateEntryReport(Tuple<LfLexEntry, Exception> t)
+        {
+            return new SingleItemReport {
+                Guid = t.Item1.Guid ?? Guid.Empty,
+                Id = null,
+                ExceptionMessage = t.Item2?.ToString(),
+                Label = DataConverters.ConvertUtilities.EntryNameForDebugging(t.Item1),
+                Entry = null
+            };
+        }
+
         public static SingleItemReport CreateEntryReport(Tuple<ILexEntry, Exception> t)
         {
             return new SingleItemReport {
                 Guid = t.Item1.Guid,
                 Id = null,
                 ExceptionMessage = t.Item2?.ToString(),
-                Label = "todo",
+                Label = DataConverters.ConvertUtilities.EntryNameForDebugging(t.Item1),
                 Entry = null
+            };
+        }
+
+        public static SingleItemReport CreateCommentReport(Tuple<LfComment, Exception, LfLexEntry, Exception> t)
+        {
+            return new SingleItemReport {
+                Guid = t.Item1.Guid ?? Guid.Empty,
+                Id = t.Item1.Id.ToString(),
+                ExceptionMessage = t.Item2?.ToString(),
+                Label = t.Item1.Content?.Substring(0, 100) ?? "<empty comment>",
+                Entry = SingleItemReport.CreateEntryReport(Tuple.Create(t.Item3, t.Item4))
             };
         }
 
@@ -109,8 +154,8 @@ namespace LfMerge.Core.Reporting
                 Guid = t.Item1.Guid ?? Guid.Empty,
                 Id = t.Item1.Id.ToString(),
                 ExceptionMessage = t.Item2?.ToString(),
-                Label = "todo",
-                Entry = SingleItemReport.CreateEntryReport(Tuple.Create(t.Item3, (Exception)null))
+                Label = t.Item1.Content?.Substring(0, 100) ?? "<empty comment>",
+                Entry = SingleItemReport.CreateEntryReport(Tuple.Create(t.Item3, null as Exception))
             };
         }
 	}

--- a/src/LfMerge.Core/Reporting/ErrorReport.cs
+++ b/src/LfMerge.Core/Reporting/ErrorReport.cs
@@ -11,11 +11,11 @@ namespace LfMerge.Core.Reporting
 {
 	public class ErrorReport
 	{
-		public DateTime Timestamp { get; set; }
+		public DateTime Timestamp { get; private set; }
 
-		public string ExceptionMessage { get; set; }
+		public string ExceptionMessage { get; private set; }
 
-		public ConversionErrorReport Skipped { get; set; }
+		public ConversionErrorReport Skipped { get; private set; }
 
 		public static ErrorReport Create(ConversionErrorReport skipped, Exception overallException)
 		{
@@ -67,8 +67,8 @@ namespace LfMerge.Core.Reporting
 
 	public class ConversionErrorReport
 	{
-		public ConversionErrors ToMongo { get; set; }
-		public ConversionErrors ToLcm { get; set; }
+		public ConversionErrors ToMongo { get; private set; }
+		public ConversionErrors ToLcm { get; private set; }
 
 		public static ConversionErrorReport Create(ConversionErrors toMongoErrors, ConversionErrors toLcmErrors)
 		{
@@ -97,8 +97,8 @@ namespace LfMerge.Core.Reporting
 
 	public class ConversionErrors
 	{
-		public ErrorList Entries { get; set; }
-		public ErrorList Comments { get; set; }
+		public ErrorList Entries { get; private set; }
+		public ErrorList Comments { get; private set; }
 
 		public static ConversionErrors FromConversionError<T>(
 			ConversionError<T> errorSet)
@@ -113,7 +113,7 @@ namespace LfMerge.Core.Reporting
 	public class ErrorList
 	{
 		public int Count { get { return List?.Count ?? 0; } }
-		public IList<SingleItemReport> List { get; set; }
+		public IList<SingleItemReport> List { get; private set; }
 
 		public static ErrorList FromEntryErrors<T>(List<EntryConversionError<T>> entryErrors)
 		{
@@ -132,11 +132,11 @@ namespace LfMerge.Core.Reporting
 
 	public class SingleItemReport
 	{
-		public Guid Guid { get; set; }
-		public string Id { get; set; }
-		public string ExceptionMessage { get; set; }
-		public string Label { get; set; }
-		public SingleItemReport Entry { get; set; }
+		public Guid Guid { get; private set; }
+		public string Id { get; private set; }
+		public string ExceptionMessage { get; private set; }
+		public string Label { get; private set; }
+		public SingleItemReport Entry { get; private set; }
 
 		public bool ShouldSerializeEntry() { return Entry != null; }
 

--- a/src/LfMerge.Core/Reporting/ErrorReport.cs
+++ b/src/LfMerge.Core/Reporting/ErrorReport.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+
+namespace LfMerge.Core.Reporting
+{
+    public class ErrorReport
+    {
+        public DateTime Timestamp { get; set; }
+
+        public string ExceptionMessage { get; set; }
+
+        public ConversionErrorReport Skipped { get; set; }
+    }
+
+    public class ConversionErrorReport
+    {
+        public ConversionErrors ToMongo { get; set; }
+        public ConversionErrors ToLcm { get; set; }
+
+    }
+
+    public class ConversionErrors 
+    {
+        public ErrorList Entries { get; set; }
+        public ErrorList Comments { get; set; }
+    }
+
+    public class ErrorList
+    {
+        public int Count { get { return List?.Count ?? 0; } }
+        public IList<SingleItemReport> List { get; set; }
+    }
+
+	public class SingleItemReport
+	{
+        public Guid Guid { get; set; }
+        public string Id { get; set; }
+        public string ExceptionMessage { get; set; }
+        public string Label { get; set; }
+        public SingleItemReport Entry { get; set; }
+
+        public bool ShouldSerializeEntry()
+        {
+            return Entry != null;
+        }
+	}
+}


### PR DESCRIPTION
Fixes #232. Will need corresponding changes to Language Forge to display the failing entries (if any) to the user; see https://github.com/sillsdev/LfMerge/issues/232#issue-1233306693 for the proposed JSON structure of the new error object. Note that the JSON property will change from `errors` to `error` (it was `Error` in the https://github.com/sillsdev/LfMerge/issues/232#issue-1233306693 proposal, but it's going to be `error` once this PR is merged).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/280)
<!-- Reviewable:end -->
