### PR TITLE
Ensure HOME env var is kept when running lfmerge

### DIFF
--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -5,6 +5,6 @@
 
 while :
 do
-  sudo -u www-data lfmergeqm
+  sudo -H -u www-data lfmergeqm
   sleep 86400
 done

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -10,7 +10,7 @@ trap "exit" TERM
 # This is expected to run as the CMD, launched by the entry point.
 
 while inotifywait -e close_write /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
-  sudo -u www-data lfmergeqm
+  sudo -H -u www-data lfmergeqm
   # Run it again just to ensure that any initial clones that missed a race condition have a chance to get noticed
-  sudo -u www-data lfmergeqm
+  sudo -H -u www-data lfmergeqm
 done


### PR DESCRIPTION
In recent versions of sudo (including the ones used in recent .NET Docker images), sudo's default behavior is to strip all kinds of environment variables, including `$HOME`. Some parts of libpalaso rely on `$HOME` being set in order to locate cache directories, so we need to set it when running lfmerge via sudo (by using the `-H` option).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/281)
<!-- Reviewable:end -->
