### PR TITLE
Create .local/share folder for www-data user

### DIFF
--- a/Dockerfile.runtime-base
+++ b/Dockerfile.runtime-base
@@ -20,4 +20,4 @@ RUN apt-get update && apt-get install -y sudo debhelper devscripts cli-common-de
 # Also ensure that www-data has a .local dir in its home directory (/var/www) since some of lfmerge's dependencies assume that $HOME/.local exists
 RUN addgroup --system --quiet fieldworks ; \
     adduser --quiet www-data fieldworks ; \
-	install -d -o www-data -g www-data -m 02775 /var/www/.local
+	install -d -o www-data -g www-data -m 02775 /var/www/.local/share


### PR DESCRIPTION
This prevents the situation where .NET, looking for the Linux equivalent of the Windows APPDATA folder, ends up returning an empty string because the user's $HOME/.local/share folder doesn't exist yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/282)
<!-- Reviewable:end -->
