### PR TITLE
Add alternate executable name for FixFwData.exe

### DIFF
--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -41,6 +41,8 @@ install -m 644 output/${BUILD}/${FRAMEWORK}/${LIBRUNTIME}/${NETSTANDARD}/*.* ${D
 install -m 755 output/${BUILD}/${FRAMEWORK}/LfMerge ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/LfMerge ${DBDESTDIR}/${LIB}
 install -m 755 output/${BUILD}/${FRAMEWORK}/LfMergeQueueManager ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/LfMergeQueueManager ${DBDESTDIR}/${LIB}
 install -m 755 output/${BUILD}/${FRAMEWORK}/chorusmerge ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/chorusmerge ${DBDESTDIR}/${LIB}
+install -m 755 output/${BUILD}/${FRAMEWORK}/FixFwData ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/FixFwData ${DBDESTDIR}/${LIB}
+(cd ${DBDESTDIR}/${LIB}; ln FixFwData FixFwData.exe)
 install -d ${DBDESTDIR}/${LIB}/Mercurial
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/convert


### PR DESCRIPTION
Existing FieldWorks code is looking for FixFwData.exe, but with .NET 6 on Linux, executables compile to names without .exe (e.g., FixFwData). Rather than change all the FieldWorks code to look for FixFwData, it's far simpler to create a hard link (basically two names pointing to the same data) so that FixFwData and FixFwData.exe both exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/283)
<!-- Reviewable:end -->
