### PR TITLE
baseline for working unit tests via pbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ MercurialExtensions/
 Mercurial/
 Downloads/
 lib/
+!lib/chorusmerge
 build/LfMerge.files
 data/php/
 data/testlangproj*/*.bak

--- a/lib/chorusmerge
+++ b/lib/chorusmerge
@@ -1,6 +1,4 @@
 #!/bin/bash
-unset MONO_PREFIX
-unset MONO_ENVIRON
 
 SCRIPT_DIR=$(dirname $(readlink -f $0))
 
@@ -32,4 +30,14 @@ cd "$SHARE"
 . ./environ
 cd "$LIB"
 
-exec mono --debug "$LIB"/ChorusMerge.exe "$@"
+if [ -e "$LIB"/ChorusMerge ]
+then
+	exec "$LIB"/ChorusMerge "$@"
+else
+	if [ -e "$LIB"/ChorusMerge.dll ]
+	then
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+	else
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+	fi
+fi

--- a/lib/chorusmerge
+++ b/lib/chorusmerge
@@ -36,8 +36,8 @@ then
 else
 	if [ -e "$LIB"/ChorusMerge.dll ]
 	then
-		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"
 	else
-		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"
 	fi
 fi

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>LfMerge.Core</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Description>LfMerge.Core</Description>
@@ -40,7 +40,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1" PrivateAssets="All" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-netcore0102" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-netcore0102" GeneratePathProperty="true" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.6.3-netcore*" />
     <PackageReference Include="SIL.Core.Desktop" Version="9.0.0" />
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />
@@ -52,6 +52,10 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
   <ItemGroup>
     <None Include="..\..\lib\chorusmerge">
       <Link>chorusmerge</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(PkgSIL_Chorus_ChorusMerge)\lib\net6.0\ChorusMerge.runtimeconfig.json">
+      <Link>ChorusMerge.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <EmbeddedResource Include="..\..\data\parts-of-speech\GOLDEtic.xml">

--- a/src/LfMerge.Core/chorusmerge
+++ b/src/LfMerge.Core/chorusmerge
@@ -30,4 +30,14 @@ cd "$SHARE"
 . ./environ
 cd "$LIB"
 
-exec dotnet run "$LIB"/ChorusMerge.exe "$@"
+if [ -e "$LIB"/ChorusMerge ]
+then
+	exec "$LIB"/ChorusMerge "$@"
+else
+	if [ -e "$LIB"/ChorusMerge.dll ]
+	then
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"
+	else
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"
+	fi
+fi

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -55,4 +55,11 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/master/CHANGELOG.
     </ItemGroup>
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
   </Target>
+
+  <Target Name="CreateChorusMergeExe" AfterTargets="CustomBuild"
+          Condition="Exists('$(OutputPath)/chorusmerge') And !Exists('$(OutputPath)/ChorusMerge.exe')">
+    <Message Text="About to run 'ln chorusmerge ChorusMerge.exe' in $(OutputPath)" />
+    <Exec Command="ln chorusmerge ChorusMerge.exe"
+			WorkingDirectory="$(OutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
improvements for finding ChorusMerge, depending on platform
moved LfMerge.Core from .NET Standard to .NET6, to fix warnings about consuming ChorusMerge
this change won't work without a local package of ChorusMerge. it needs the updates to Program.cs. once that PR is merged, we can update the reference here and remove the need for a local nuget source

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge/287)
<!-- Reviewable:end -->
