### PR TITLE
Rename `live` to `master`, build alpha Docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [ develop, live ]
+    branches: [ develop, master ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,28 @@ jobs:
         echo "Tag for FW9 (DbVersion 72): (${TAG72})"
 
     - name: Tag release branches
-      if: github.event_name == 'push' && github.ref == 'refs/heads/live'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       env:
         TAG72: ${{ inputs.TagFor7000072 }}
       run: |
         git config --global user.name "github-actions"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git tag -f -a -m "Release ${TAG72}" "${TAG72}" "refs/remotes/origin/live"
+        git tag -f -a -m "Release ${TAG72}" "${TAG72}" "refs/remotes/origin/master"
         git push -v origin "${TAG72}"
+
+    - name: Calculate Docker tags
+      id: docker_tag
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+      env:
+        MS_BUILD_VERSION: ${{ inputs.MsBuildVersion }}
+      run: |
+        if [ "${GITHUB_REF}" == 'refs/heads/master' ]
+        then
+          TAGS=ghcr.io/sillsdev/lfmerge:${MS_BUILD_VERSION},ghcr.io/sillsdev/lfmerge:latest
+        else
+          TAGS=ghcr.io/sillsdev/lfmerge:${MS_BUILD_VERSION}
+        fi
+        echo "::set-output name=DockerTags::${TAGS}"
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2.0.10
@@ -51,7 +65,7 @@ jobs:
       run: ls -lR tarball
 
     - name: Login to GHCR
-      if: github.event_name == 'push' && github.ref == 'refs/heads/live'
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -64,8 +78,8 @@ jobs:
       uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
       # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
       with:
-        push: ${{(github.event_name == 'push' && github.ref == 'refs/heads/live')}}
-        tags: ghcr.io/sillsdev/lfmerge:${{ inputs.MsBuildVersion }},ghcr.io/sillsdev/lfmerge:latest
+        push: ${{(github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'))}}
+        tags: ${{ steps.version.docker_tag.DockerTags }}
         context: .
         file: Dockerfile.finalresult
 

--- a/docker/scripts/get-version-number.sh
+++ b/docker/scripts/get-version-number.sh
@@ -40,7 +40,7 @@ case "$REV" in
     PRERELEASE="~alpha.${BUILD_NUMBER}"
     ;;
 
-  refs/heads/live)
+  refs/heads/master)
     PRERELEASE=
     ;;
 

--- a/src/LfMerge.Core/Logging/ExceptionLogging.cs
+++ b/src/LfMerge.Core/Logging/ExceptionLogging.cs
@@ -180,7 +180,7 @@ namespace LfMerge.Core.Logging
 			{
 				var gitBranch = MainClass.GetVersionInfo("BranchName");
 
-				if (gitBranch.EndsWith("/live", StringComparison.InvariantCulture))
+				if (gitBranch.EndsWith("/master", StringComparison.InvariantCulture))
 					configuration.ReleaseStage = "live";
 				else if (gitBranch.StartsWith("origin/", StringComparison.InvariantCulture))
 					configuration.ReleaseStage = "development";


### PR DESCRIPTION
This completes the branch renaming process, and also builds (and pushes) Docker images from the `develop` branch so that we can more easily test them on the staging server without needing to merge possibly-untested code to the `live` branch in order to deploy and test it.

This should **not** be merged until everyone who has a copy of LfMerge checked out has had a chance to rename their `master` branches to `develop`, otherwise things will get extremely confusing.