### PR TITLE
Get build working with fixed chorusmerge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ MercurialExtensions/
 Mercurial/
 Downloads/
 lib/
+!lib/chorusmerge
 build/LfMerge.files
 data/php/
 data/testlangproj*/*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -
 
 FROM lfmerge-builder-base AS lfmerge-build-7000072
 ENV DbVersion=7000072
+ENV DBVERSION=7000072
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000072
 ENV RUN_UNIT_TESTS=0
 ENV NUNIT_VERSION_MAJOR=3
@@ -25,7 +26,7 @@ ENV NUNIT_VERSION_MAJOR=3
 FROM lfmerge-build-${DbVersion} AS lfmerge-build
 
 # So unit tests can run
-RUN mkdir -p /var/lib/languageforge/lexicon/sendreceive/ \
+RUN mkdir -p /usr/lib/lfmerge/${DbVersion} /var/lib/languageforge/lexicon/sendreceive/ \
 	&& cd /var/lib/languageforge/lexicon/sendreceive/ && mkdir Templates state editqueue syncqueue webwork && cd - \
 	&& chown -R builder:users /var/lib/languageforge/lexicon/sendreceive
 

--- a/Dockerfile.finalresult
+++ b/Dockerfile.finalresult
@@ -25,6 +25,8 @@ COPY lfmergeqm-background.sh /
 COPY lfmergeqm-looping.sh /
 COPY entrypoint.sh /
 RUN chmod +x /lfmergeqm-background.sh /lfmergeqm-looping.sh /entrypoint.sh
+# ENV DbVersion=${DbVersion}
+# ENV DBVERSION=${DbVersion}
 
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/entrypoint.sh" ]
 CMD [ "/lfmergeqm-looping.sh" ]

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Local copy of Chorus PR" value="./local" />
+  </packageSources>
+</configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Local copy of Chorus PR" value="./local" />
-  </packageSources>
-</configuration>

--- a/environ
+++ b/environ
@@ -4,7 +4,7 @@
 # the sourcing script should cd/pushd to the directory containing this script
 BASE="$(pwd)"
 
-export PATH="${BASE}/output/${BUILD}:${BASE}/output/Mercurial:${PATH}"
+export PATH="${BASE}/output/${BUILD}/net6.0:${BASE}/output/Mercurial:${PATH}"
 
 # set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
 # incompatible with our version of Mercurial

--- a/lfmergeqm
+++ b/lfmergeqm
@@ -33,7 +33,9 @@ then
   fi
 fi
 
-DBVERSION=$(basename $(find /usr/lib/lfmerge -maxdepth 1 -type d -name [0-9]\* | sort | tail -n 1))
+if [ -z "$DBVERSION" ]; then
+	DBVERSION=$(basename $(find /usr/lib/lfmerge -maxdepth 1 -type d -name [0-9]\* | sort | tail -n 1))
+fi
 LIB=/usr/lib/lfmerge/$DBVERSION
 SHARE=/usr/share/lfmerge/$DBVERSION
 

--- a/lib/chorusmerge
+++ b/lib/chorusmerge
@@ -1,6 +1,4 @@
 #!/bin/bash
-unset MONO_PREFIX
-unset MONO_ENVIRON
 
 SCRIPT_DIR=$(dirname $(readlink -f $0))
 
@@ -32,4 +30,14 @@ cd "$SHARE"
 . ./environ
 cd "$LIB"
 
-exec mono --debug "$LIB"/ChorusMerge.exe "$@"
+if [ -e "$LIB"/ChorusMerge ]
+then
+	exec "$LIB"/ChorusMerge "$@"
+else
+	if [ -e "$LIB"/ChorusMerge.dll ]
+	then
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+	else
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+	fi
+fi

--- a/lib/chorusmerge
+++ b/lib/chorusmerge
@@ -36,8 +36,8 @@ then
 else
 	if [ -e "$LIB"/ChorusMerge.dll ]
 	then
-		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"
 	else
-		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"
 	fi
 fi

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.PlatformAbstractions;
 using NUnit.Framework;
 using SIL.LCModel;
 using SIL.TestUtilities;
+using System.Text.RegularExpressions;
 
 namespace LfMerge.Core.Tests.Actions
 {
@@ -205,7 +206,8 @@ namespace LfMerge.Core.Tests.Actions
 			string errors = _env.Logger.GetErrors();
 			Assert.That(errors, Does.Contain("System.Xml.XmlException"));
 			// Stack trace should also have been logged
-			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow"));
+			var regex = new Regex(@"^\s*at Chorus\.sync\.Synchronizer\.SyncNow.*SyncOptions options", RegexOptions.Multiline);
+			Assert.That(errors, Does.Match(regex));
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 
@@ -229,7 +231,8 @@ namespace LfMerge.Core.Tests.Actions
 			string errors = _env.Logger.GetErrors();
 			Assert.That(errors, Does.Contain("System.Xml.XmlException: '.', hexadecimal value 0x00, is an invalid character."));
 			// Stack trace should also have been logged
-			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow"));
+			var regex = new Regex(@"^\s*at Chorus\.sync\.Synchronizer\.SyncNow.*SyncOptions options", RegexOptions.Multiline);
+			Assert.That(errors, Does.Match(regex));
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -205,7 +205,7 @@ namespace LfMerge.Core.Tests.Actions
 			string errors = _env.Logger.GetErrors();
 			Assert.That(errors, Does.Contain("System.Xml.XmlException"));
 			// Stack trace should also have been logged
-			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow (Chorus.sync.SyncOptions options)"));
+			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow"));
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 
@@ -229,7 +229,7 @@ namespace LfMerge.Core.Tests.Actions
 			string errors = _env.Logger.GetErrors();
 			Assert.That(errors, Does.Contain("System.Xml.XmlException: '.', hexadecimal value 0x00, is an invalid character."));
 			// Stack trace should also have been logged
-			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow (Chorus.sync.SyncOptions options)"));
+			Assert.That(errors, Does.Contain("\n  at Chorus.sync.Synchronizer.SyncNow"));
 			Assert.That(_lfProject.State.SRState, Is.EqualTo(ProcessingState.SendReceiveStates.SYNCING));
 		}
 

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>LfMerge.Core</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Description>LfMerge.Core</Description>

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -39,10 +39,10 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="MongoDB.Driver.Core.signed" Version="2.14.*" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1" PrivateAssets="All" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-netcore0102" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.4" PrivateAssets="All" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-pr0279-0136" GeneratePathProperty="true" /> <!-- -->
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.6.3-netcore*" />
-    <PackageReference Include="SIL.Core.Desktop" Version="9.0.0" />
+    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0" />
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.Lexicon" Version="10.0.0-*" />
@@ -52,6 +52,10 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
   <ItemGroup>
     <None Include="..\..\lib\chorusmerge">
       <Link>chorusmerge</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(PkgSIL_Chorus_ChorusMerge)\lib\net6.0\ChorusMerge.runtimeconfig.json">
+      <Link>ChorusMerge.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <EmbeddedResource Include="..\..\data\parts-of-speech\GOLDEtic.xml">

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -40,7 +40,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.4" PrivateAssets="All" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-pr0279-0136" GeneratePathProperty="true" /> <!-- -->
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-beta0030" GeneratePathProperty="true" /> <!-- -->
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.6.3-netcore*" />
     <PackageReference Include="SIL.Core.Desktop" Version="10.0.0" />
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>LfMerge.Core</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Description>LfMerge.Core</Description>

--- a/src/LfMerge.Core/chorusmerge
+++ b/src/LfMerge.Core/chorusmerge
@@ -36,8 +36,8 @@ then
 else
 	if [ -e "$LIB"/ChorusMerge.dll ]
 	then
-		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"
 	else
-		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"
 	fi
 fi

--- a/src/LfMerge.Core/chorusmerge
+++ b/src/LfMerge.Core/chorusmerge
@@ -30,4 +30,14 @@ cd "$SHARE"
 . ./environ
 cd "$LIB"
 
-exec dotnet run "$LIB"/ChorusMerge.exe "$@"
+if [ -e "$LIB"/ChorusMerge ]
+then
+	exec "$LIB"/ChorusMerge "$@"
+else
+	if [ -e "$LIB"/ChorusMerge.dll ]
+	then
+		exec dotnet "$LIB"/ChorusMerge.dll "$@"  # Failed 3 Passed 2
+	else
+		exec dotnet run "$LIB"/ChorusMerge.exe "$@"  # How about this?
+	fi
+fi

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -56,7 +56,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
   </Target>
 
-  <Target Name="CreateChorusMergeExe" AfterTargets="CustomBuild" Condition="Exists('$(OutputPath)/ChorusMerge') And !Exists('$(OutputPath)/ChorusMerge.exe')">
+  <Target Name="CreateChorusMergeExe" AfterTargets="CustomBuild" Condition="Exists('$(OutputPath)/chorusmerge') And !Exists('$(OutputPath)/ChorusMerge.exe')">
     <Message Text="About to run 'ln chorusmerge ChorusMerge.exe' in $(OutputPath)" />
     <Exec Command="ln chorusmerge ChorusMerge.exe"
 			WorkingDirectory="$(OutputPath)" />

--- a/src/LfMerge/LfMerge.csproj
+++ b/src/LfMerge/LfMerge.csproj
@@ -55,4 +55,10 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     </ItemGroup>
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
   </Target>
+
+  <Target Name="CreateChorusMergeExe" AfterTargets="CustomBuild" Condition="Exists('$(OutputPath)/ChorusMerge') And !Exists('$(OutputPath)/ChorusMerge.exe')">
+    <Message Text="About to run 'ln chorusmerge ChorusMerge.exe' in $(OutputPath)" />
+    <Exec Command="ln chorusmerge ChorusMerge.exe"
+			WorkingDirectory="$(OutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
This PR will eventually supersede #287. It requires downloading the build artifacts from https://github.com/sillsdev/chorus/pull/279 and unzipping them into a folder named `local` at the root of the LfMerge repository. Then the `dotnet restore` step will consume those packages (thanks to the `NuGet.config` file included in this PR), which means it will pull in the `chorusmerge` bugfix from https://github.com/sillsdev/chorus/pull/279. With that bugfix, all unit tests finally pass.