### PR TITLE
mkdir ~/.nuget/packages dir if necessary

### DIFF
--- a/pbuild.sh
+++ b/pbuild.sh
@@ -61,6 +61,8 @@ done
 # Clean out previous installation files if they exist
 [ -d tarball ] && rm -rf tarball
 
+mkdir -p ${HOME}/.nuget/packages 
+
 # Run the build
 for DbVersion in ${DBMODEL_VERSIONS[@]}; do
 	docker run -it \


### PR DESCRIPTION
This directory is expected on the host system and referenced in the pbuild.sh script.

Since I am a new C# dev, I did not have the directory already and the LFMerge build failed.  This ensures the build will succeed on brand new machines like mine.