### PR TITLE
Run unit tests in GHA workflow and report results

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,6 +78,12 @@ jobs:
           InformationalVersion: ${{ steps.version.outputs.InformationalVersion }}
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
+      - name: Report test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          nunit_files: "**/TestResults/TestResults.xml"
+
       - name: Compress tarball images for faster uploads
         run: time (tar cf - tarball | gzip -c9 > tarball.tar.gz)
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ output/
 MercurialExtensions/
 Mercurial/
 Downloads/
+TestResults/
 lib/
 !lib/chorusmerge
 build/LfMerge.files

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM lfmerge-builder-base AS lfmerge-build-7000072
 ENV DbVersion=7000072
 ENV DBVERSION=7000072
 ENV DBVERSIONPATH=/usr/lib/lfmerge/7000072
-ENV RUN_UNIT_TESTS=0
+ENV RUN_UNIT_TESTS=1
 ENV NUNIT_VERSION_MAJOR=3
 # ENV TEST_SPEC=LfMerge.Core.Tests.Actions.SynchronizeActionTests.SynchronizeAction_CustomReferenceAtomicField_DoesNotThrowExceptionDuringSync
 

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+# Commented out due to `dotnet test` crashing even on successful tests
+# Once we upgrade to a version of `dotnet test` that no longer crashes, uncomment the "set -e" line
+# set -e
 
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
 

--- a/docker/scripts/build-and-test.sh
+++ b/docker/scripts/build-and-test.sh
@@ -29,9 +29,9 @@ if [ -n "$RUN_UNIT_TESTS" -a "$RUN_UNIT_TESTS" -ne 0 ]; then
 	export VSTEST_TESTHOST_SHUTDOWN_TIMEOUT=30000  # 30 seconds, please, since some of our tests can run very long
 	# Treat TEST_SPEC enviornment variable as a "contains" operation
 	if [ -n "$TEST_SPEC" ]; then
-		dotnet test --no-restore -c Release --filter "FullyQualifiedName~${TEST_SPEC}"
+		dotnet test --no-restore -l:"console;verbosity=normal" -l:nunit -c Release --filter "FullyQualifiedName~${TEST_SPEC}"
 	else
-		dotnet test --no-restore -c Release
+		dotnet test --no-restore -l:"console;verbosity=normal" -l:nunit -c Release
 	fi
 fi
 

--- a/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
+++ b/src/LfMerge.Core.Tests/LfMerge.Core.Tests.csproj
@@ -34,6 +34,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="Moq" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnitXml.TestLogger" Version="3.0.117" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.1" />
     <PackageReference Include="SIL.LCModel.Core.Tests" Version="10.1.0-beta0382" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -46,7 +46,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.Lexicon" Version="10.0.0-*" />
-    <PackageReference Include="CommandLineParser" Version="2.2.0" />
+    <PackageReference Include="CommandLineParser" Version="2.7.82" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LfMerge.Tests/LfMerge.Tests.csproj
+++ b/src/LfMerge.Tests/LfMerge.Tests.csproj
@@ -34,6 +34,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnitXml.TestLogger" Version="3.0.117" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>


### PR DESCRIPTION
This runs the unit tests by default in the GHA workflow (setting RUN_UNIT_TESTS to 1 by default) and reports the test results in the GHA workflow logs. It uses the https://github.com/marketplace/actions/publish-test-results action to report the results; see that documentation for how to configure the reporting locations if desired.