### PR TITLE
LfMerge completes S/R's with .NET6

### DIFF
--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -51,7 +51,7 @@ install -m 644 output/${BUILD}/${FRAMEWORK}/${LIBRUNTIME}/${NETSTANDARD}/*.* ${D
 install -m 755 output/${BUILD}/${FRAMEWORK}/LfMerge ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/LfMerge ${DBDESTDIR}/${LIB}
 install -m 755 output/${BUILD}/${FRAMEWORK}/LfMergeQueueManager ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/LfMergeQueueManager ${DBDESTDIR}/${LIB}
 install -m 755 output/${BUILD}/${FRAMEWORK}/chorusmerge ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/chorusmerge ${DBDESTDIR}/${LIB}
-install -m 755 output/${BUILD}/${FRAMEWORK}/FixFwData ${DBDESTDIR}/${LIB} 2>/dev/null || install -m 755 output/${BUILD}/FixFwData ${DBDESTDIR}/${LIB}
+chmod 755 ${DBDESTDIR}/${LIB}/FixFwData.exe
 install -d ${DBDESTDIR}/${LIB}/Mercurial
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext
 install -d ${DBDESTDIR}/${LIB}/Mercurial/hgext/convert

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -42,6 +42,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.4" PrivateAssets="All" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-beta0030" GeneratePathProperty="true" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.8.0-beta*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.1.0-beta0018" />
     <PackageReference Include="SIL.Core.Desktop" Version="10.0.0" />
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />


### PR DESCRIPTION
This fixes a bug during sync where the exe couldn't be run due to permissions. I also removed FixFwData, since the production environment was working without it.

Both a change to FixFwData and Chorus are needed to launch successfully. Once the Chorus PR is merged, this can be readied.