### PR TITLE
increased min model version from *68 to *72

### DIFF
--- a/src/LfMerge.Core.Tests/MainClassTests.cs
+++ b/src/LfMerge.Core.Tests/MainClassTests.cs
@@ -28,8 +28,8 @@ namespace LfMerge.Core
 
 		[TestCase("7000060", ExpectedResult = false)]
 		[TestCase("7000067", ExpectedResult = false)]
-		[TestCase("7000068", ExpectedResult = true)]
-		[TestCase("7000069", ExpectedResult = true)]
+		[TestCase("7000068", ExpectedResult = false)]
+		[TestCase("7000069", ExpectedResult = false)]
 		[TestCase("7000071", ExpectedResult = false)]
 		[TestCase("7000072", ExpectedResult = true)]
 		public bool IsSupportedModelVersion(string modelVersion)

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -8,7 +8,7 @@ namespace LfMerge.Core
 	{
 		static MagicStrings()
 		{
-			MinimalModelVersion = 7000068;
+			MinimalModelVersion = 7000072;
 		}
 
 		// Environment variables used by LfMerge


### PR DESCRIPTION
this removes support for FW8 projects. before, it was causing LfMerge to crash. now, doing this in LF displays the desired red box and maintains a good state for that user.