### PR TITLE
Update LibChorus so we can use the new 10MB limit

### DIFF
--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -39,11 +39,11 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="MongoDB.Driver.Core.signed" Version="2.14.*" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.4" PrivateAssets="All" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.6" PrivateAssets="All" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="5.0.0-beta0030" GeneratePathProperty="true" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.8.0-beta*" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.1.0-beta0018" />
-    <PackageReference Include="SIL.Core.Desktop" Version="10.0.0" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="5.1.0-beta0025" />
+    <PackageReference Include="SIL.Core.Desktop" Version="11.0.0-beta0047" />
     <PackageReference Include="SIL.LCModel" Version="10.2.0-netcore0083" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="SIL.Lexicon" Version="10.0.0-*" />


### PR DESCRIPTION
Fixes #315

We want to make use of the new [10MB file limit in Chorus](https://github.com/sillsdev/chorus/pull/301).

Base on timestamps, I think that `[5.1.0-beta0024](https://www.nuget.org/packages/SIL.Chorus.LibChorus/5.1.0-beta0024)` would have been the newest version ([from this list](https://www.nuget.org/packages/SIL.Chorus.LibChorus/5.1.0-beta0028#versions-body-tab)) with the desired feature. But I updated a bit higher due to some `Detected package downgrade` warnings:
```
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605: Detected package downgrade: SIL.Chorus.LibChorus from 5.1.0-beta0025 to 5.1.0-beta0024. Reference the package directly from the project to select a different version. 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.ChorusPlugin.LfMergeBridge 3.8.0-beta0008 -> SIL.Chorus.LibChorus (>= 5.1.0-beta0025) 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.Chorus.LibChorus (>= 5.1.0-beta0024)
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605: Detected package downgrade: SIL.Chorus.Mercurial from 3.0.3.6 to 3.0.3.4. Reference the package directly from the project to select a different version. 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.Chorus.LibChorus 5.1.0-beta0024 -> SIL.Chorus.Mercurial (>= 3.0.3.6) 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.Chorus.Mercurial (>= 3.0.3.4)
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605: Detected package downgrade: SIL.Core.Desktop from 11.0.0-beta0047 to 10.0.0. Reference the package directly from the project to select a different version. 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.Chorus.LibChorus 5.1.0-beta0024 -> SIL.Lift 11.0.0-beta0047 -> SIL.Core.Desktop (>= 11.0.0-beta0047) 
/home/tim_haasdyk/LfMerge/src/LfMerge.Core/LfMerge.Core.csproj : error NU1605:  LfMerge.Core -> SIL.Core.Desktop (>= 10.0.0)
```

Using my change I successfully synced an 8.7MB file, while the 10.5MB file was not synced:
![image](https://user-images.githubusercontent.com/12587509/211591586-89f985ee-fc7d-4908-9f92-63e086673e99.png)

Project: https://public.languagedepot.org/projects/test-chris-01
Entry name: `File size sync test`