### PR TITLE
Use new GitHub environment files

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -13,20 +13,17 @@ jobs:
       uses: actions/checkout@v3.0.2
 
     - name: Set up buildx for Docker
-      # docker/setup-buildx-action@v2.0.0 is commit dc7b9719a96d48369863986a06765841d7ea23f6
-      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+      uses: docker/setup-buildx-action@v2.2.1
 
     - name: Login to GHCR
-      # docker/login-action@v2.0.0 is commit 49ed152c8eca782a232dede0303416e8f356c37b
-      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+      uses: docker/login-action@v2.1.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build base Docker image (builder)
-      # docker/build-push-action@v3.0.0 is commit e551b19e49efd4e98792db7592c17c09b89db8d8
-      uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+      uses: docker/build-push-action@v3.3.0
       with:
         push: true
         tags: ghcr.io/sillsdev/lfmerge-base:sdk
@@ -34,8 +31,7 @@ jobs:
         file: Dockerfile.builder-base
 
     - name: Build base Docker image (runtime)
-      # docker/build-push-action@v3.0.0 is commit e551b19e49efd4e98792db7592c17c09b89db8d8
-      uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+      uses: docker/build-push-action@v3.3.0
       with:
         push: true
         tags: ghcr.io/sillsdev/lfmerge-base:runtime

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,13 +47,12 @@ jobs:
 
       - name: Find current UID
         id: uid
-        run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
+        #run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
+        run: echo "name=developer::chris" >> $GITHUB_OUTPUT
 
       - name: Output diagnostics
         run: |
-          echo "here is the uid = ${{steps.uid.outputs.uid}}"
-          echo "here is the GITHUB_OUTPUT"
-          cat $GITHUB_OUTPUT
+          echo "the developer is = ${{steps.uid.outputs.developer}}"
           
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,11 +51,7 @@ jobs:
 
       - name: Output diagnostics
         run: |
-          for i in "${!steps.uid.outputs[@]}"
-            do
-            echo "key  : $i"
-            echo "value: ${array[$i]}"
-          done
+          echo "here is the uid = ${{steps.uid.outputs.uid}}"
           
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Find current UID
         id: uid
-        #run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
-        run: echo "developer=chris" >> $GITHUB_OUTPUT
+        run: |
+          echo "uid=$(id -u)" >> $GITHUB_OUTPUT
+          echo "developer=chris" >> $GITHUB_OUTPUT
 
       - name: Output diagnostics
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,8 +51,7 @@ jobs:
         run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
 
       - name: Build DBVersion-specific Docker image
-        # docker/build-push-action@v3.0.0 is commit e551b19e49efd4e98792db7592c17c09b89db8d8
-        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
+        uses: docker/build-push-action@v3.3.0
         with:
           push: false
           load: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Find current UID
         id: uid
         #run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
-        run: echo "name=developer::chris" >> $GITHUB_OUTPUT
+        run: echo "developer=chris" >> $GITHUB_OUTPUT
 
       - name: Output diagnostics
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Output diagnostics
         run: |
           echo "here is the uid = ${{steps.uid.outputs.uid}}"
+          echo "here is the GITHUB_OUTPUT"
+          cat $GITHUB_OUTPUT
           
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,6 +49,10 @@ jobs:
         id: uid
         run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
 
+      - name: Output diagnostics
+        run: |
+          echo "{{steps.uid.outputs}}"
+          
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,8 +43,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.MsBuildVersion }}
 
       - name: Set up buildx for Docker
-        # docker/setup-buildx-action@v2.0.0 is commit dc7b9719a96d48369863986a06765841d7ea23f6
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Find current UID
         id: uid

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,8 +36,8 @@ jobs:
         id: output_version_number
         run: |
           echo Will tag ${{matrix.dbversion}} with ${TAG}
-          echo "name=TagFor${{matrix.dbversion}}::${TAG}" >> $GITHUB_OUTPUT
-          echo "name=VersionFor${{matrix.dbversion}}::${VERSION}" >> $GITHUB_OUTPUT
+          echo "TagFor${{matrix.dbversion}}=${TAG}" >> $GITHUB_OUTPUT
+          echo "VersionFor${{matrix.dbversion}}=${VERSION}" >> $GITHUB_OUTPUT
         env:
           TAG: v${{ steps.version.outputs.MsBuildVersion }}
           VERSION: ${{ steps.version.outputs.MsBuildVersion }}
@@ -47,9 +47,7 @@ jobs:
 
       - name: Find current UID
         id: uid
-        run: |
-          echo "uid=$(id -u)" >> $GITHUB_OUTPUT
-          echo "developer=chris" >> $GITHUB_OUTPUT
+        run: echo "uid=$(id -u)" >> $GITHUB_OUTPUT
 
       - name: Output diagnostics
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Output diagnostics
         run: |
-          echo "{{steps.uid.outputs}}"
+          echo "${{steps.uid.outputs}}"
           
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,11 @@ jobs:
 
       - name: Output diagnostics
         run: |
-          echo "${{steps.uid.outputs}}"
+          for i in "${!steps.uid.outputs[@]}"
+            do
+            echo "key  : $i"
+            echo "value: ${array[$i]}"
+          done
           
       - name: Build DBVersion-specific Docker image
         uses: docker/build-push-action@v3.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,8 +36,8 @@ jobs:
         id: output_version_number
         run: |
           echo Will tag ${{matrix.dbversion}} with ${TAG}
-          echo "::set-output name=TagFor${{matrix.dbversion}}::${TAG}"
-          echo "::set-output name=VersionFor${{matrix.dbversion}}::${VERSION}"
+          echo "name=TagFor${{matrix.dbversion}}::${TAG}" >> $GITHUB_OUTPUT
+          echo "name=VersionFor${{matrix.dbversion}}::${VERSION}" >> $GITHUB_OUTPUT
         env:
           TAG: v${{ steps.version.outputs.MsBuildVersion }}
           VERSION: ${{ steps.version.outputs.MsBuildVersion }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Find current UID
         id: uid
-        run: echo "::set-output name=uid::$(id -u)"
+        run: echo "name=uid::$(id -u)" >> $GITHUB_OUTPUT
 
       - name: Build DBVersion-specific Docker image
         # docker/build-push-action@v3.0.0 is commit e551b19e49efd4e98792db7592c17c09b89db8d8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         else
           TAGS=ghcr.io/sillsdev/lfmerge:${MS_BUILD_VERSION}
         fi
-        echo "name=DockerTags::${TAGS}" >> $GITHUB_OUTPUT
+        echo "DockerTags=${TAGS}" >> $GITHUB_OUTPUT
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2.0.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,7 @@ jobs:
 
     - name: Build final Docker image
       id: lfmerge_image
-      # docker/build-push-action@v2.7.0 is commit a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-      uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-      # TODO: Follow https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md for tagging
+      uses: docker/build-push-action@v3.3.0
       with:
         push: ${{(github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'))}}
         tags: ${{ steps.docker_tag.outputs.DockerTags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         else
           TAGS=ghcr.io/sillsdev/lfmerge:${MS_BUILD_VERSION}
         fi
-        echo "::set-output name=DockerTags::${TAGS}"
+        echo "name=DockerTags::${TAGS}" >> $GITHUB_OUTPUT
 
     - name: Download build artifacts
       uses: actions/download-artifact@v2.0.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID
-RUN test -n $BUILDER_UID
 ENV BUILDER_UID=$BUILDER_UID
-
+RUN test -n $BUILDER_UID
 
 # # Build as a non-root user
 RUN useradd -u ${BUILDER_UID:-DEFAULT_BUILDER_UID} -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID
-ENV BUILDER_UID=$BUILDER_UID
 RUN test -n $BUILDER_UID
+ENV BUILDER_UID=$BUILDER_UID
 
 # # Build as a non-root user
 RUN useradd -u ${BUILDER_UID:-DEFAULT_BUILDER_UID} -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID
-ENV BUILDER_UID="$BUILDER_UID"
-RUN test -n "$BUILDER_UID"
+RUN test -n $BUILDER_UID
+ENV BUILDER_UID=$BUILDER_UID
 
 
 # # Build as a non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID
-RUN test -n $BUILDER_UID
-ENV BUILDER_UID=$BUILDER_UID
+RUN test -n "$BUILDER_UID"
+ENV BUILDER_UID="$BUILDER_UID"
 
 # # Build as a non-root user
-RUN useradd -u ${BUILDER_UID:-DEFAULT_BUILDER_UID} -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \
+RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
 	chown -R builder:users /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM ghcr.io/sillsdev/lfmerge-base:sdk AS lfmerge-builder-base
 
 ENV DEFAULT_BUILDER_UID=1000
 ARG BUILDER_UID
-RUN test -n "$BUILDER_UID"
 ENV BUILDER_UID="$BUILDER_UID"
+RUN test -n "$BUILDER_UID"
+
 
 # # Build as a non-root user
 RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV BUILDER_UID=$BUILDER_UID
 
 
 # # Build as a non-root user
-RUN useradd -u "${BUILDER_UID:-DEFAULT_BUILDER_UID}" -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \
+RUN useradd -u ${BUILDER_UID:-DEFAULT_BUILDER_UID} -d /home/builder -g users -G www-data,fieldworks -m -s /bin/bash builder ; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers; \
 	chown -R builder:users /build
 

--- a/docker/scripts/get-version-number.sh
+++ b/docker/scripts/get-version-number.sh
@@ -74,9 +74,9 @@ GIT_SHA=${GITHUB_SHA:-$(git rev-parse ${REV})}
 TAG_SUFFIX="$(date +%Y%m%d)-${GIT_SHA}"
 export InformationalVersion="${MsBuildVersion}${INFO_SUFFIX}:${TAG_SUFFIX}"
 echo "Calculated version number ${MsBuildVersion} for ${DbVersion}"
-echo "::set-output name=DebPackageVersion::${DebPackageVersion}"
-echo "::set-output name=MsBuildVersion::${MsBuildVersion}"
-echo "::set-output name=MajorMinorPatch::${MajorMinorPatch}"
-echo "::set-output name=AssemblySemVer::${AssemblySemVer}"
-echo "::set-output name=AssemblySemFileVer::${AssemblySemFileVer}"
-echo "::set-output name=InformationalVersion::${InformationalVersion}"
+echo "name=DebPackageVersion::${DebPackageVersion}" >> $GITHUB_OUTPUT
+echo "name=MsBuildVersion::${MsBuildVersion}" >> $GITHUB_OUTPUT
+echo "name=MajorMinorPatch::${MajorMinorPatch}" >> $GITHUB_OUTPUT
+echo "name=AssemblySemVer::${AssemblySemVer}" >> $GITHUB_OUTPUT
+echo "name=AssemblySemFileVer::${AssemblySemFileVer}" >> $GITHUB_OUTPUT
+echo "name=InformationalVersion::${InformationalVersion}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We are editing GitHub workflows to use [new GitHub environment files](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) , replacing deprecated commands. 