### PR TITLE
Update login-actions and download-artifact, correct output syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         echo "DockerTags=${TAGS}" >> $GITHUB_OUTPUT
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v2.0.10
+      uses: actions/download-artifact@v3
       with:
         # No name specified, so will download all artifacts
         path: all-tarballs
@@ -66,7 +66,7 @@ jobs:
 
     - name: Login to GHCR
       if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2.1.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/docker/scripts/get-version-number.sh
+++ b/docker/scripts/get-version-number.sh
@@ -74,9 +74,9 @@ GIT_SHA=${GITHUB_SHA:-$(git rev-parse ${REV})}
 TAG_SUFFIX="$(date +%Y%m%d)-${GIT_SHA}"
 export InformationalVersion="${MsBuildVersion}${INFO_SUFFIX}:${TAG_SUFFIX}"
 echo "Calculated version number ${MsBuildVersion} for ${DbVersion}"
-echo "name=DebPackageVersion::${DebPackageVersion}" >> $GITHUB_OUTPUT
-echo "name=MsBuildVersion::${MsBuildVersion}" >> $GITHUB_OUTPUT
-echo "name=MajorMinorPatch::${MajorMinorPatch}" >> $GITHUB_OUTPUT
-echo "name=AssemblySemVer::${AssemblySemVer}" >> $GITHUB_OUTPUT
-echo "name=AssemblySemFileVer::${AssemblySemFileVer}" >> $GITHUB_OUTPUT
-echo "name=InformationalVersion::${InformationalVersion}" >> $GITHUB_OUTPUT
+echo "DebPackageVersion=${DebPackageVersion}" >> $GITHUB_OUTPUT
+echo "MsBuildVersion=${MsBuildVersion}" >> $GITHUB_OUTPUT
+echo "MajorMinorPatch=${MajorMinorPatch}" >> $GITHUB_OUTPUT
+echo "AssemblySemVer=${AssemblySemVer}" >> $GITHUB_OUTPUT
+echo "AssemblySemFileVer=${AssemblySemFileVer}" >> $GITHUB_OUTPUT
+echo "InformationalVersion=${InformationalVersion}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Additional fixes for #318 (Resolve warnings in LF Merge builds). Also see earlier PR #319.

Completed a[ clean run](https://github.com/sillsdev/LfMerge/actions/runs/3964277185) of the release action on this branch.