### PR TITLE
Update remaining dependencies to resolve build warnings

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v3
 
     - name: Set up buildx for Docker
-      uses: docker/setup-buildx-action@v2.2.1
+      uses: docker/setup-buildx-action@v2.4.1
 
     - name: Login to GHCR
       uses: docker/login-action@v2.1.0
@@ -23,7 +23,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build base Docker image (builder)
-      uses: docker/build-push-action@v3.3.0
+      uses: docker/build-push-action@v4.0.0
       with:
         push: true
         tags: ghcr.io/sillsdev/lfmerge-base:sdk
@@ -31,7 +31,7 @@ jobs:
         file: Dockerfile.builder-base
 
     - name: Build base Docker image (runtime)
-      uses: docker/build-push-action@v3.3.0
+      uses: docker/build-push-action@v4.0.0
       with:
         push: true
         tags: ghcr.io/sillsdev/lfmerge-base:runtime

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out current branch
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # All history for all tags and branches, since version number script needs that
 
@@ -43,7 +43,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.MsBuildVersion }}
 
       - name: Set up buildx for Docker
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v2.4.1
 
       - name: Find current UID
         id: uid
@@ -54,7 +54,7 @@ jobs:
           echo "the developer is = ${{steps.uid.outputs.developer}}"
           
       - name: Build DBVersion-specific Docker image
-        uses: docker/build-push-action@v3.3.0
+        uses: docker/build-push-action@v4.0.0
         with:
           push: false
           load: true
@@ -81,7 +81,7 @@ jobs:
         run: docker run --mount type=bind,source="$(pwd)",target=/home/builder/repo --env "BUILD_NUMBER=${BUILD_NUMBER}" --env "DebPackageVersion=${DebPackageVersion}" --env "Version=${MsBuildVersion}" --env "MajorMinorPatch=${MajorMinorPatch}" --env "AssemblyVersion=${AssemblySemVer}" --env "FileVersion=${AssemblySemFileVer}" --env "InformationalVersion=${InformationalVersion}" --name tmp-lfmerge-build-${{matrix.dbversion}} lfmerge-build-${{matrix.dbversion}}
 
       - name: Report test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2.3.0
         if: always()
         with:
           nunit_files: "**/TestResults/TestResults.xml"
@@ -89,7 +89,7 @@ jobs:
       - name: Compress tarball images for faster uploads
         run: time (tar cf - tarball | gzip -c9 > tarball.tar.gz)
 
-      - uses: actions/upload-artifact@v3.0.0
+      - uses: actions/upload-artifact@v3
         with:
           name: lfmerge-tarball
           path: tarball.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
 
     - name: Build final Docker image
       id: lfmerge_image
-      uses: docker/build-push-action@v3.3.0
+      uses: docker/build-push-action@v4.0.0
       with:
         push: ${{(github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'))}}
         tags: ${{ steps.docker_tag.outputs.DockerTags }}


### PR DESCRIPTION
Fixes #318

We have received warnings about the deprecated `save-state` command syntax, which was found in prior versions of some of our dependencies. This PR updates all of our dependencies to the most recent version.