### PR TITLE
Remove warning about syslog logger deprecation

### DIFF
--- a/src/LfMerge.Core/MainClass.cs
+++ b/src/LfMerge.Core/MainClass.cs
@@ -52,9 +52,6 @@ namespace LfMerge.Core
 			string logDest =
 				System.Environment.GetEnvironmentVariable(MagicStrings.EnvVar_LoggingDest) ??
 				System.Environment.GetEnvironmentVariable(MagicStrings.EnvVar_LoggingDestination) ?? "-";
-			if (logDest == "syslog") {
-				Console.WriteLine("WARNING: syslog logging no longer available, logging to console instead");
-			}
 			// TODO: Implement a FileLogger to handle cases where the logDest is a filename, then only use ConsoleLogger if env var is "-" or missing
 			string stderrThreshholdStr = System.Environment.GetEnvironmentVariable(MagicStrings.EnvVar_LoggingStderrTreshhold) ?? "-";
 			LogSeverity stderrThreshhold;


### PR DESCRIPTION
It's been over a year, time to get rid of the now-meaningless warning.

Fixes #311.