### PR TITLE
Remove two redundant string.Format calls

### DIFF
--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -142,15 +142,15 @@ namespace LfMerge
 
 				if (project.State.SRState != ProcessingState.SendReceiveStates.ERROR)
 				{
-					MainClass.Logger.Error(string.Format(
+					MainClass.Logger.Error(
 						"Putting project '{0}' on hold due to unhandled exception: \n{1}",
-						projectCode, e));
+						projectCode, e);
 					if (project != null)
 					{
 						project.State.SetErrorState(ProcessingState.SendReceiveStates.HOLD,
-							ProcessingState.ErrorCodes.UnhandledException, string.Format(
+							ProcessingState.ErrorCodes.UnhandledException,
 								"Putting project '{0}' on hold due to unhandled exception: \n{1}",
-								projectCode, e));
+								projectCode, e);
 					}
 				}
 			}


### PR DESCRIPTION
A couple of `string.Format` calls in [Program.cs](src/LfMerge/Program.cs) are redundant, as the logging and state-processing code already calls string.Format, and this could theoretically cause an exception if the error message passed in happened to contain strings like `{0}`.

This is a very unlikely scenario and I haven't yet encountered it in the wild, but there's no reason for our code to do extra work *and* be more brittle than it needs to be.