### PR TITLE
update LCM version to include memory mapped file fix (again)

### DIFF
--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -44,9 +44,9 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="3.8.0-beta*" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="5.2.0-beta0002" />
     <PackageReference Include="SIL.Core.Desktop" Version="12.0.0" />
-    <PackageReference Include="SIL.LCModel" Version="10.2.0-beta0072" />
+    <PackageReference Include="SIL.LCModel" Version="11.0.0-beta0077" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.Lexicon" Version="11.0.1" />
+    <PackageReference Include="SIL.Lexicon" Version="12.0.0" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
   </ItemGroup>
 


### PR DESCRIPTION
include https://github.com/sillsdev/liblcm/pull/287 which should fix https://github.com/sillsdev/LfMerge/issues/317