### PR TITLE
Use username & password (from env vars) for Mongo

### DIFF
--- a/src/LfMerge.Core/LanguageDepotProject.cs
+++ b/src/LfMerge.Core/LanguageDepotProject.cs
@@ -24,7 +24,7 @@ namespace LfMerge.Core
 		public void Initialize(string lfProjectCode)
 		{
 			// TODO: This should use the MongoConnection class instead
-			MongoClient client = new MongoClient("mongodb://" + Settings.MongoDbHostNameAndPort);
+			MongoClient client = new MongoClient("mongodb://" + Settings.MongoDbHostPortAndAuth);
 			IMongoDatabase database = client.GetDatabase("scriptureforge");
 			IMongoCollection<BsonDocument> projectCollection = database.GetCollection<BsonDocument>("projects");
 			//var userCollection = database.GetCollection<BsonDocument>("users");

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -20,6 +20,9 @@ namespace LfMerge.Core
 		public const string SettingsEnvVar_TemplatesDir = "LFMERGE_TEMPLATES_DIR";
 		public const string SettingsEnvVar_MongoHostname = "LFMERGE_MONGO_HOSTNAME";
 		public const string SettingsEnvVar_MongoPort = "LFMERGE_MONGO_PORT";
+		public const string SettingsEnvVar_MongoAuthSource = "LFMERGE_MONGO_AUTHSOURCE";
+		public const string SettingsEnvVar_MongoUsername = "LFMERGE_MONGO_USER";
+		public const string SettingsEnvVar_MongoPassword = "LFMERGE_MONGO_PASS";
 		public const string SettingsEnvVar_MongoMainDatabaseName = "LFMERGE_MONGO_MAIN_DB_NAME";
 		public const string SettingsEnvVar_MongoDatabaseNamePrefix = "LFMERGE_MONGO_DB_NAME_PREFIX";
 		public const string SettingsEnvVar_VerboseProgress = "LFMERGE_VERBOSE_PROGRESS";

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -74,7 +74,7 @@ namespace LfMerge.Core.MongoConnector
 			_settings = settings;
 			_logger = logger;
 			connectionString = string.Format(
-				"mongodb://{0}&authSource={1}",
+				"mongodb://{0}?authSource={1}",
 				Settings.MongoDbHostPortAndAuth,
 				Settings.MongoAuthSource);
 			mainDatabaseName = Settings.MongoMainDatabaseName;

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -27,6 +27,7 @@ namespace LfMerge.Core.MongoConnector
 
 	public class MongoConnection : IMongoConnection
 	{
+		private string connectionString;
 		private string mainDatabaseName;
 		private Lazy<IMongoClient> client;
 		// Since calling GetDatabase() too often creates a new connection, we memoize the databases in this dictionary.
@@ -72,6 +73,10 @@ namespace LfMerge.Core.MongoConnector
 		{
 			_settings = settings;
 			_logger = logger;
+			connectionString = string.Format(
+				"mongodb://{0}&authSource={1}",
+				Settings.MongoDbHostPortAndAuth,
+				Settings.MongoAuthSource);
 			mainDatabaseName = Settings.MongoMainDatabaseName;
 			client = new Lazy<IMongoClient>(GetNewConnection);
 			dbs = new ConcurrentDictionary<string, IMongoDatabase>();
@@ -79,7 +84,7 @@ namespace LfMerge.Core.MongoConnector
 
 		private MongoClient GetNewConnection()
 		{
-			var clientSettings = new MongoClientSettings();
+			var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
 			// clientSettings.WriteConcern = WriteConcern.WMajority; // If increasing the wait queue size still doesn't help, try this as well
 			clientSettings.WaitQueueSize = 50000;
 			clientSettings.Server = new MongoServerAddress(Settings.MongoHostname, Settings.MongoPort);

--- a/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
@@ -12,6 +12,10 @@ namespace LfMerge.Core.Settings
 		public const int MongoPort = 27017;
 		public const string MongoMainDatabaseName = "scriptureforge";
 		public const string MongoDatabaseNamePrefix = "sf_";
+		public const string MongoAuthSource = "admin";
+		// Mongo username and password defaults should be *empty*
+		public const string MongoUsername = "";
+		public const string MongoPassword = "";
 		public const bool VerboseProgress = false;
 		public const string LanguageDepotRepoUri = "";  // optional, usually not set
 	}

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -44,6 +44,12 @@ namespace LfMerge.Core.Settings
 			}
 		}
 
+		public string MongoAuthSource => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoAuthSource) ?? DefaultLfMergeSettings.MongoAuthSource;
+		public string MongoUsername => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoUsername) ?? DefaultLfMergeSettings.MongoUsername;
+		public string MongoPassword => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPassword) ?? DefaultLfMergeSettings.MongoPassword;
+		private string EncodedUsername => Uri.EscapeUriString(MongoUsername);
+		private string EncodedPassword => Uri.EscapeUriString(MongoPassword);
+
 		public string MongoMainDatabaseName => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoMainDatabaseName) ?? DefaultLfMergeSettings.MongoMainDatabaseName;
 
 		/// <summary>
@@ -65,6 +71,9 @@ namespace LfMerge.Core.Settings
 		public bool CommitWhenDone { get; internal set; }
 
 		public string MongoDbHostNameAndPort { get { return String.Format("{0}:{1}", MongoHostname, MongoPort.ToString()); } }
+		public string MongoDbHostPortAndAuth => string.IsNullOrEmpty(MongoUsername) || string.IsNullOrEmpty(MongoPassword)
+			? string.Format("{0}:{1}", MongoHostname, MongoPort.ToString())
+			: string.Format("{0}:{1}@{2}:{3}", EncodedUsername, EncodedPassword, MongoHostname, MongoPort.ToString());
 
 		private string QueueDirectory { get; set; }
 


### PR DESCRIPTION
Mongo connections can now use a username and password, specified by enviornment variables. If the environment variables are not present or are empty, then no authentication parameters are sent to Mongo.

Env vars used to specify the username and password will be `LFMERGE_MONGO_USER` and `LFMERGE_MONGO_PASS`, matching the convention used for other LfMerge env vars. `LFMERGE_MONGO_AUTHSOURCE` can also optionally be set to give the name of the MongoDB database where authentication is stored (default is `admin` and will probably not need changing).

Part of https://github.com/sillsdev/web-languageforge/issues/1787, but closing this PR should not close that issue. The linked PR in the LF repo will be the one to close that issue.