### PR TITLE
Refactor SyncAction tests to use real FwProjects pushing to local Mercurial server

### DIFF
--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -277,7 +277,7 @@ namespace LfMerge.Core.Tests.Actions
 		// Also returns the entry so that calling code can grab the updated date they want.
 		public (DateTime, DateTime, LfLexEntry) UpdateLfEntry(LanguageForgeProject lfProject, Guid entryId, Action<LfLexEntry> updater)
 		{
-			var lfEntry = _mongoConnection.GetLfLexEntryByGuid(entryId);
+			var lfEntry = _mongoConnection.GetLfLexEntryByGuid(lfProject, entryId);
 			Assert.That(lfEntry, Is.Not.Null);
 			updater(lfEntry);
 			// Remember that in LfMerge it's AuthorInfo that corresponds to the Lcm modified date
@@ -332,7 +332,7 @@ namespace LfMerge.Core.Tests.Actions
 			sutSynchronize.Run(_lfProject);
 
 			// Verify
-			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			Assert.That(updatedLfEntry.Senses[0].Gloss["en"].Value, Is.EqualTo(unchangedGloss + " - changed in LF"));
 			// LF had the same data previously; however it's a merge conflict so DateModified got updated
 			Assert.That(updatedLfEntry.DateModified, Is.GreaterThan(origDateModified));
@@ -362,7 +362,7 @@ namespace LfMerge.Core.Tests.Actions
 			Assert.That(receivedMongoData, Is.Not.Null);
 			// Deleting entries in LF should *not* remove them, just set the isDeleted flag
 			Assert.That(receivedMongoData.Count(), Is.EqualTo(originalNumOfLcmEntries));
-			var entry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var entry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			Assert.That(entry, Is.Not.Null);
 			Assert.That(entry.IsDeleted, Is.EqualTo(true));
 			Assert.That(entry.DateModified, Is.GreaterThan(origDateModified));
@@ -397,7 +397,7 @@ namespace LfMerge.Core.Tests.Actions
 			sutSynchronize.Run(_lfProject);
 
 			// Verify
-			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			Assert.That(updatedLfEntry.IsDeleted, Is.False);
 			Assert.That(updatedLfEntry.Senses[0].Gloss["en"].Value, Is.EqualTo(unchangedGloss + " - changed in FW"));
 			// LF entry's modified date updated when it was restored from being deleted
@@ -421,7 +421,7 @@ namespace LfMerge.Core.Tests.Actions
 			CommitAndPush(_fwProject);
 
 			// Now LF project deletes sense from entry
-			var lfEntry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var lfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			var origDateModified = lfEntry.DateModified;
 			var origAuthorInfoModifiedDate = lfEntry.AuthorInfo.ModifiedDate;
 
@@ -436,7 +436,7 @@ namespace LfMerge.Core.Tests.Actions
 			sutSynchronize.Run(_lfProject);
 
 			// Verify
-			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			Assert.That(updatedLfEntry.Senses[0].Gloss["en"].Value, Is.EqualTo(unchangedGloss + " - changed in FW"));
 			// LF entry's modified date updated when the sense was restored from being deleted
 			Assert.That(updatedLfEntry.DateModified, Is.GreaterThan(origDateModified));
@@ -467,7 +467,7 @@ namespace LfMerge.Core.Tests.Actions
 			sutSynchronize.Run(_lfProject);
 
 			// Verify
-			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_testDeletedEntryGuid);
+			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testDeletedEntryGuid);
 			Assert.That(updatedLfEntry, Is.Not.Null);
 			Assert.That(updatedLfEntry.Senses[0].Gloss["en"].Value, Is.EqualTo("new English gloss - added in LF"));
 			// LF had the same data previously; however it's a merge conflict so DateModified got updated
@@ -499,7 +499,7 @@ namespace LfMerge.Core.Tests.Actions
 			sutSynchronize.Run(_lfProject);
 
 			// Verify
-			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_testEntryGuid);
+			var updatedLfEntry = _mongoConnection.GetLfLexEntryByGuid(_lfProject, _testEntryGuid);
 			Assert.That(updatedLfEntry.Senses[0].Gloss["en"].Value, Is.EqualTo(unchangedGloss + " - changed in FW"));
 			Assert.That(updatedLfEntry.Note["en"].Value, Is.EqualTo("A note from LF"));
 			// LF had the same data previously; however it's a merge conflict so DateModified got updated

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionTests.cs
@@ -273,17 +273,6 @@ namespace LfMerge.Core.Tests.Actions
 			Assert.That(GetGlossFromLanguageDepot(_testEntryGuid, 2), Is.EqualTo(ldChangedGloss));
 		}
 
-		// Returns original AuthorInfo.ModifiedDate, followed by *updated* AuthorInfo.ModifiedDate. Does not return either the old or new DateModified values.
-		public (string, DateTime, DateTime) UpdateLfEntry(LanguageForgeProject lfProject, Guid entryId, Func<LfLexEntry, LfStringField> getField, Func<string, string> textConverter)
-		{
-			string unchangedValue = null;
-			var (origModifiedDate, _, lfEntry) = UpdateLfEntry(lfProject, entryId, lfEntry => {
-				unchangedValue = getField(lfEntry).Value;
-				getField(lfEntry).Value = textConverter(unchangedValue);
-			});
-			return (unchangedValue, origModifiedDate, lfEntry.AuthorInfo.ModifiedDate);
-		}
-
 		// Returns original AuthorInfo.ModifiedDate, followed by original DateModified. (This order is chosen because DateModified is only useful in delete tests)
 		// Also returns the entry so that calling code can grab the updated date they want.
 		public (DateTime, DateTime, LfLexEntry) UpdateLfEntry(LanguageForgeProject lfProject, Guid entryId, Action<LfLexEntry> updater)
@@ -297,6 +286,17 @@ namespace LfMerge.Core.Tests.Actions
 			lfEntry.AuthorInfo.ModifiedDate = lfEntry.DateModified = DateTime.UtcNow;
 			_mongoConnection.UpdateRecord(lfProject, lfEntry);
 			return (origModifiedDate, origDateModified, lfEntry);
+		}
+
+		// Returns original AuthorInfo.ModifiedDate, followed by *updated* AuthorInfo.ModifiedDate. Does not return either the old or new DateModified values.
+		public (string, DateTime, DateTime) UpdateLfEntry(LanguageForgeProject lfProject, Guid entryId, Func<LfLexEntry, LfStringField> getField, Func<string, string> textConverter)
+		{
+			string unchangedValue = null;
+			var (origModifiedDate, _, lfEntry) = UpdateLfEntry(lfProject, entryId, lfEntry => {
+				unchangedValue = getField(lfEntry).Value;
+				getField(lfEntry).Value = textConverter(unchangedValue);
+			});
+			return (unchangedValue, origModifiedDate, lfEntry.AuthorInfo.ModifiedDate);
 		}
 
 		// Returns original DateModified, followed by *updated* DateModified. Does not return either the old or new AuthorInfo.ModifiedDate values.

--- a/src/LfMerge.Core.Tests/LcmTestHelper.cs
+++ b/src/LfMerge.Core.Tests/LcmTestHelper.cs
@@ -32,6 +32,15 @@ namespace LfMerge.Core.Tests
 			return repo.AllInstances().First();
 		}
 
+		public static void DeleteEntry(FwProject project, Guid guid)
+		{
+			var entry = GetEntry(project, guid);
+			var accessor = project.Cache.ActionHandlerAccessor;
+			UndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW("undo", "redo", accessor, () => {
+				entry.Delete();
+			});
+		}
+
 		public static string? GetVernacularText(IMultiUnicode field)
 		{
 			return field.BestVernacularAlternative?.Text;

--- a/src/LfMerge.Core/FieldWorks/FwProject.cs
+++ b/src/LfMerge.Core/FieldWorks/FwProject.cs
@@ -35,6 +35,10 @@ namespace LfMerge.Core.FieldWorks
 			}
 		}
 
+		public string FwdataPath => _project.Path;
+		public string ProjectDir => _project.ProjectFolder;
+		public string ProjectCode => _project.Name;
+
 		#region Disposable stuff
 
 		#if DEBUG


### PR DESCRIPTION
Fixes #346.

This PR converts all the SyncAction tests to use a real FwProject and call liblcm methods in order to edit it, rather than using pre-edited data in the testlangproj-modified project. This makes the tests easier to read (a LOT easier in some cases), as the changes expected in the FW project are visible in the test instead of being hidden away in non-code data. It also is a lot more flexible in terms of what kinds of future tests can be written, because it will be much simpler to load up a FW project and make whatever changes are needed.

One SyncAction test, testing a FW regression, was not converted; see https://github.com/sillsdev/LfMerge/pull/347#issuecomment-2301401753 for the rationale. (Briefly, it's because I wouldn't be able to prove that the regression test was still testing the right thing).