### PR TITLE
Use real MongoDB connection for E2E tests

### DIFF
--- a/src/LfMerge.Core.Tests/E2E/E2ETestBase.cs
+++ b/src/LfMerge.Core.Tests/E2E/E2ETestBase.cs
@@ -98,7 +98,7 @@ namespace LfMerge.Core.Tests.E2E
 			var outcome = TestContext.CurrentContext.Result.Outcome;
 			var success = outcome == ResultState.Success || outcome == ResultState.Ignored;
 			// Only delete temp folder if test passed, otherwise we'll want to leave it in place for post-test investigation
-			TestEnv.DeleteTempFolderDuringCleanup = success;
+			TestEnv.CleanUpTestData = success;
 			// On failure, also leave LexBox project(s) in place for post-test investigation, even though this might tend to clutter things up a little
 			if (success) {
 				foreach (var projId in ProjectIdsToDelete) {

--- a/src/LfMerge.Core.Tests/E2E/E2ETestBase.cs
+++ b/src/LfMerge.Core.Tests/E2E/E2ETestBase.cs
@@ -81,7 +81,6 @@ namespace LfMerge.Core.Tests.E2E
 				Assert.Ignore("Can't run E2E tests without a copy of LexBox to test against. Please either launch LexBox on localhost port 80, or set the appropriate environment variables to point to a running copy of LexBox.");
 			}
 			await TestEnv.Login();
-			Console.WriteLine("About to launch Mongo...");
 			TestEnv.LaunchMongo();
 
 			MagicStrings.SetMinimalModelVersion(LcmCache.ModelVersion);

--- a/src/LfMerge.Core.Tests/E2E/LexboxSendReceiveTests.cs
+++ b/src/LfMerge.Core.Tests/E2E/LexboxSendReceiveTests.cs
@@ -50,7 +50,7 @@ namespace LfMerge.Core.Tests.E2E
 			// Verify
 
 			// LF side should win conflict since its modified date was later
-			var lfEntryAfterSR = _mongoConnection.GetLfLexEntryByGuid(entryId);
+			var lfEntryAfterSR = _mongoConnection.GetLfLexEntryByGuid(lfProject, entryId);
 			Assert.That(lfEntryAfterSR?.Senses?[0]?.Gloss?["pt"]?.Value, Is.EqualTo(unchangedGloss + " - changed in LF"));
 			// LF's modified dates should have been updated by the sync action
 			Assert.That(lfEntryAfterSR.AuthorInfo.ModifiedDate, Is.GreaterThan(origLfDateModified));

--- a/src/LfMerge.Core.Tests/Lcm/RoundTripTests.cs
+++ b/src/LfMerge.Core.Tests/Lcm/RoundTripTests.cs
@@ -830,7 +830,7 @@ namespace LfMerge.Core.Tests.Lcm
 			// Here we check two things:
 			// 1) Can we add paragraphs?
 			// 2) Can we change existing paragraphs?
-			LfLexEntry lfEntry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry lfEntry = _conn.GetLfLexEntryByGuid(lfProject, entryGuid);
 			// BsonDocument customFieldValues = GetCustomFieldValues(cache, lcmEntry, "entry");
 			BsonDocument customFieldsBson = lfEntry.CustomFields;
 			Assert.That(customFieldsBson.Contains("customField_entry_Cust_MultiPara"), Is.True,
@@ -923,7 +923,7 @@ namespace LfMerge.Core.Tests.Lcm
 
 			// Here we check just one thing:
 			// 1) Can we delete paragraphs?
-			LfLexEntry lfEntry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry lfEntry = _conn.GetLfLexEntryByGuid(lfProject, entryGuid);
 			// BsonDocument customFieldValues = GetCustomFieldValues(cache, lcmEntry, "entry");
 			BsonDocument customFieldsBson = lfEntry.CustomFields;
 			Assert.That(customFieldsBson.Contains("customField_entry_Cust_MultiPara"), Is.True,

--- a/src/LfMerge.Core.Tests/Lcm/TransferMongoToLcmActionTests.cs
+++ b/src/LfMerge.Core.Tests/Lcm/TransferMongoToLcmActionTests.cs
@@ -234,7 +234,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			LcmCache cache = lfProj.FieldWorksProject.Cache;
 			string vernacularWS = cache.LanguageProject.DefaultVernacularWritingSystem.Id;
 			string changedLexeme = "modified lexeme for this test";
@@ -263,7 +263,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 
@@ -325,7 +325,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			LcmCache cache = lfProj.FieldWorksProject.Cache;
 			string vernacularWS = cache.LanguageProject.DefaultVernacularWritingSystem.Id;
 			string changedLexeme = "modified lexeme for this test";
@@ -335,7 +335,7 @@ namespace LfMerge.Core.Tests.Lcm
 			_conn.UpdateMockLfLexEntry(entry);
 
 			Guid kenGuid = Guid.Parse(KenEntryGuidStr);
-			LfLexEntry kenEntry = _conn.GetLfLexEntryByGuid(kenGuid);
+			LfLexEntry kenEntry = _conn.GetLfLexEntryByGuid(lfProj, kenGuid);
 			string changedLexeme2 = "modified lexeme #2 for this test";
 			kenEntry.Lexeme = LfMultiText.FromSingleStringMapping(vernacularWS, changedLexeme2);
 			kenEntry.AuthorInfo = new LfAuthorInfo();
@@ -362,11 +362,11 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 			Guid kenGuid = Guid.Parse(KenEntryGuidStr);
-			entry = _conn.GetLfLexEntryByGuid(kenGuid);
+			entry = _conn.GetLfLexEntryByGuid(lfProj, kenGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 
@@ -430,7 +430,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			LcmCache cache = lfProj.FieldWorksProject.Cache;
 			string vernacularWS = cache.LanguageProject.DefaultVernacularWritingSystem.Id;
 			string changedLexeme = "modified lexeme for this test";
@@ -470,7 +470,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 
@@ -557,7 +557,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			LcmCache cache = lfProj.FieldWorksProject.Cache;
 			string vernacularWS = cache.LanguageProject.DefaultVernacularWritingSystem.Id;
 			string changedLexeme = "modified lexeme for this test";
@@ -606,7 +606,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 
@@ -621,7 +621,7 @@ namespace LfMerge.Core.Tests.Lcm
 			Assert.That(LfMergeBridgeServices.FormatCommitMessageForLfMerge(_counts.Added, _counts.Modified, _counts.Deleted),
 				Is.EqualTo("Language Forge: 1 entry deleted"));
 
-			entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			entry.IsDeleted = true;
 			_conn.UpdateMockLfLexEntry(entry);
 
@@ -689,7 +689,7 @@ namespace LfMerge.Core.Tests.Lcm
 			SutLcmToMongo.Run(lfProj);
 
 			Guid entryGuid = Guid.Parse(TestEntryGuidStr);
-			LfLexEntry entry = _conn.GetLfLexEntryByGuid(entryGuid);
+			LfLexEntry entry = _conn.GetLfLexEntryByGuid(lfProj, entryGuid);
 			LfSense sense = entry.Senses[whichSense];
 			SetCustomMultiOptionList(sense, "customField_senses_Cust_Multi_ListRef", desiredKeys);
 			entry.AuthorInfo = new LfAuthorInfo();

--- a/src/LfMerge.Core.Tests/SRTestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/SRTestEnvironment.cs
@@ -96,7 +96,14 @@ namespace LfMerge.Core.Tests
 		{
 			if (_disposed) return;
 			if (disposing) {
-				StopMongo();
+				// Set the LFMERGE_E2E_LEAVE_MONGO_CONTAINER_RUNNING_ON_FAILURE env var to a non-empty value if you want Mongo container to NOT be torn down on test failure
+				if (CleanUpTestData || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(MagicStrings.EnvVar_E2E_LeaveMongoContainerRunningOnFailure))) {
+					StopMongo();
+				} else {
+					Console.WriteLine($"Leaving Mongo container {MongoContainerId} around to examine data on failed test.");
+					Console.WriteLine($"It is listening on {Settings.MongoDbHostNameAndPort}");
+					Console.WriteLine($"To delete it, run `docker stop {MongoContainerId} ; docker rm {MongoContainerId}`.");
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/src/LfMerge.Core.Tests/SRTestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/SRTestEnvironment.cs
@@ -92,12 +92,19 @@ namespace LfMerge.Core.Tests
 			}
 		}
 
+		private bool ShouldStopMongoOnFailure()
+		{
+			// Mongo container will be torn down on test failure unless LFMERGE_E2E_LEAVE_MONGO_CONTAINER_RUNNING_ON_FAILURE
+			// is set to a non-empty value (except "false" or "0", which mean the same as leaving it empty)
+			var envVar = Environment.GetEnvironmentVariable(MagicStrings.EnvVar_E2E_LeaveMongoContainerRunningOnFailure)?.Trim();
+			return string.IsNullOrEmpty(envVar) || envVar == "false" || envVar == "0";
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed) return;
 			if (disposing) {
-				// Set the LFMERGE_E2E_LEAVE_MONGO_CONTAINER_RUNNING_ON_FAILURE env var to a non-empty value if you want Mongo container to NOT be torn down on test failure
-				if (CleanUpTestData || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(MagicStrings.EnvVar_E2E_LeaveMongoContainerRunningOnFailure))) {
+				if (CleanUpTestData || ShouldStopMongoOnFailure()) {
 					StopMongo();
 				} else {
 					Console.WriteLine($"Leaving Mongo container {MongoContainerId} around to examine data on failed test.");

--- a/src/LfMerge.Core.Tests/SRTestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/SRTestEnvironment.cs
@@ -67,7 +67,6 @@ namespace LfMerge.Core.Tests
 			{
 				var result = CommandLineRunner.Run("docker", "run -p 27017 -d mongo:6", ".", 30, NullProgress);
 				MongoContainerId = result.StandardOutput?.TrimEnd();
-				Console.WriteLine($"Launched Mongo container {MongoContainerId ?? "(null) - something went wrong"}");
 				if (MongoContainerId != null)
 				{
 					result = CommandLineRunner.Run("docker", $"port {MongoContainerId} 27017", ".", 30, NullProgress);
@@ -77,7 +76,6 @@ namespace LfMerge.Core.Tests
 						Settings.MongoHostname = parts[0].Replace("0.0.0.0", "localhost");
 						Settings.MongoPort = parts[1];
 					}
-					Console.WriteLine($"Mongo is listening on port {parts?[1] ?? hostAndPort + " (oops, mongoPort was null)"}");
 				}
 			}
 		}
@@ -86,10 +84,8 @@ namespace LfMerge.Core.Tests
 		{
 			if (MongoContainerId is not null)
 			{
-				Console.WriteLine($"Stopping Mongo container {MongoContainerId} ...");
 				CommandLineRunner.Run("docker", $"stop {MongoContainerId}", ".", 30, NullProgress);
 				CommandLineRunner.Run("docker", $"rm {MongoContainerId}", ".", 30, NullProgress);
-				Console.WriteLine($"Stopped Mongo container {MongoContainerId} ...");
 				MongoContainerId = null;
 			}
 		}
@@ -98,7 +94,13 @@ namespace LfMerge.Core.Tests
 		{
 			if (_disposed) return;
 			if (disposing) {
-				StopMongo();
+				if (CleanUpTestData) {
+					StopMongo();
+				} else {
+					Console.WriteLine($"Leaving Mongo container {MongoContainerId} around to examine data on failed test.");
+					Console.WriteLine($"It is listening on {Settings.MongoDbHostNameAndPort}");
+					Console.WriteLine($"To delete it, run `docker stop {MongoContainerId} ; docker rm {MongoContainerId}`.");
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/src/LfMerge.Core.Tests/SRTestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/SRTestEnvironment.cs
@@ -97,9 +97,11 @@ namespace LfMerge.Core.Tests
 				if (CleanUpTestData) {
 					StopMongo();
 				} else {
-					Console.WriteLine($"Leaving Mongo container {MongoContainerId} around to examine data on failed test.");
-					Console.WriteLine($"It is listening on {Settings.MongoDbHostNameAndPort}");
-					Console.WriteLine($"To delete it, run `docker stop {MongoContainerId} ; docker rm {MongoContainerId}`.");
+					if (MongoContainerId is not null) {
+						Console.WriteLine($"Leaving Mongo container {MongoContainerId} around to examine data on failed test.");
+						Console.WriteLine($"It is listening on {Settings.MongoDbHostNameAndPort}");
+						Console.WriteLine($"To delete it, run `docker stop {MongoContainerId} ; docker rm {MongoContainerId}`.");
+					}
 				}
 			}
 			base.Dispose(disposing);

--- a/src/LfMerge.Core.Tests/TestDoubles.cs
+++ b/src/LfMerge.Core.Tests/TestDoubles.cs
@@ -211,7 +211,7 @@ namespace LfMerge.Core.Tests
 			return new List<LfLexEntry>(_storedLfLexEntries.Values.Select(entry => DeepCopy(entry)));
 		}
 
-		public LfLexEntry GetLfLexEntryByGuid(Guid key)
+		public LfLexEntry GetLfLexEntryByGuid(ILfProject _project, Guid key)
 		{
 			LfLexEntry result;
 			if (_storedLfLexEntries.TryGetValue(key, out result))

--- a/src/LfMerge.Core.Tests/TestEnvironment.cs
+++ b/src/LfMerge.Core.Tests/TestEnvironment.cs
@@ -26,7 +26,7 @@ namespace LfMerge.Core.Tests
 		private readonly bool                  _resetLfProjectsDuringCleanup;
 		private readonly bool                  _releaseSingletons;
 		protected        bool                  _disposed;
-		public           bool                  DeleteTempFolderDuringCleanup { get; set; } = true;
+		public           bool                  CleanUpTestData { get; set; } = true;
 		public           LfMergeSettings       Settings;
 		private readonly MongoConnectionDouble _mongoConnection;
 		public ILogger Logger => MainClass.Logger;
@@ -123,7 +123,7 @@ namespace LfMerge.Core.Tests
 				MainClass.Container = null;
 				if (_resetLfProjectsDuringCleanup)
 					LanguageForgeProjectAccessor.Reset();
-				if (DeleteTempFolderDuringCleanup)
+				if (CleanUpTestData)
 					_languageForgeServerFolder?.Dispose();
 				Settings = null;
 				if (_releaseSingletons)

--- a/src/LfMerge.Core/MagicStrings.cs
+++ b/src/LfMerge.Core/MagicStrings.cs
@@ -33,6 +33,7 @@ namespace LfMerge.Core
 		public const string EnvVar_LanguageDepotUriPort = "LFMERGE_LANGUAGE_DEPOT_HG_PORT";
 		public const string EnvVar_TrustToken = "LANGUAGE_DEPOT_TRUST_TOKEN";
 		public const string EnvVar_HgUsername = "LANGUAGE_DEPOT_HG_USERNAME";
+		public const string EnvVar_E2E_LeaveMongoContainerRunningOnFailure = "LFMERGE_E2E_LEAVE_MONGO_CONTAINER_RUNNING_ON_FAILURE";
 
 		public static Dictionary<string, string> LcmOptionlistNames = new Dictionary<string, string>()
 		{

--- a/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/IMongoConnection.cs
@@ -19,6 +19,7 @@ namespace LfMerge.Core.MongoConnector
 		IEnumerable<TDocument> GetRecords<TDocument>(ILfProject project, string collectionName);
 		LfOptionList GetLfOptionListByCode(ILfProject project, string listCode);
 		long LexEntryCount(ILfProject project);
+		LfLexEntry GetLfLexEntryByGuid(ILfProject project, Guid key);
 		Dictionary<Guid, DateTime> GetAllModifiedDatesForEntries(ILfProject project);
 		bool UpdateRecord(ILfProject project, LfLexEntry data);
 		bool UpdateRecord(ILfProject project, LfOptionList data, string listCode);

--- a/src/LfMerge.Core/MongoConnector/MongoConnection.cs
+++ b/src/LfMerge.Core/MongoConnector/MongoConnection.cs
@@ -562,7 +562,7 @@ namespace LfMerge.Core.MongoConnector
 			MongoProjectRecord oldProjectRecord = collection.FindOneAndUpdate(filter, update, updateOptions);
 
 			// For initial clone, also update field writing systems accordingly
-			if (project.IsInitialClone)
+			if (oldProjectRecord != null && project.IsInitialClone)
 			{
 				// Currently only MultiText fields have input systems in the config. If MultiParagraph fields acquire input systems as well,
 				// we'll need to add those to the logic below.

--- a/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/DefaultLfMergeSettings.cs
@@ -9,7 +9,7 @@ namespace LfMerge.Core.Settings
 		public const string WebworkDir = "webwork";
 		public const string TemplatesDir = "Templates";
 		public const string MongoHostname = "localhost";
-		public const int MongoPort = 27017;
+		public const int MongoPort = 27017; // This should stay an int even though the LfMergeSettings value is a string
 		public const string MongoMainDatabaseName = "scriptureforge";
 		public const string MongoDatabaseNamePrefix = "sf_";
 		public const string MongoAuthSource = "admin";

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -72,7 +72,7 @@ namespace LfMerge.Core.Settings
 
 		public bool CommitWhenDone { get; internal set; }
 
-		public string MongoDbHostNameAndPort { get { return String.Format("{0}:{1}", MongoHostname, MongoPort); } }
+		public string MongoDbHostNameAndPort => $"{MongoHostname}:{MongoPort}";
 		public string MongoDbHostPortAndAuth => string.IsNullOrEmpty(MongoUsername) || string.IsNullOrEmpty(MongoPassword)
 			? string.Format("{0}:{1}", MongoHostname, MongoPort)
 			: string.Format("{0}:{1}@{2}:{3}", EncodedUsername, EncodedPassword, MongoHostname, MongoPort);

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -30,18 +30,16 @@ namespace LfMerge.Core.Settings
 			}
 		}
 
-		public string MongoHostname => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoHostname) ?? DefaultLfMergeSettings.MongoHostname;
+		private string _mongoHostname;
+		public string MongoHostname {
+			get => _mongoHostname ?? Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoHostname) ?? DefaultLfMergeSettings.MongoHostname;
+			set => _mongoHostname = value;
+		}
 
-		public int MongoPort {
-			get {
-				string _mongoPortStr = Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort);
-				if (_mongoPortStr == null) _mongoPortStr = "";
-				if (Int32.TryParse(_mongoPortStr, out int _mongoPort)) {
-					return _mongoPort;
-				} else {
-					return DefaultLfMergeSettings.MongoPort;
-				}
-			}
+		private string _mongoPort;
+		public string MongoPort {
+			get => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort) ?? DefaultLfMergeSettings.MongoPort.ToString();
+			set => _mongoPort = value;
 		}
 
 		public string MongoAuthSource => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoAuthSource) ?? DefaultLfMergeSettings.MongoAuthSource;
@@ -74,10 +72,10 @@ namespace LfMerge.Core.Settings
 
 		public bool CommitWhenDone { get; internal set; }
 
-		public string MongoDbHostNameAndPort { get { return String.Format("{0}:{1}", MongoHostname, MongoPort.ToString()); } }
+		public string MongoDbHostNameAndPort { get { return String.Format("{0}:{1}", MongoHostname, MongoPort); } }
 		public string MongoDbHostPortAndAuth => string.IsNullOrEmpty(MongoUsername) || string.IsNullOrEmpty(MongoPassword)
-			? string.Format("{0}:{1}", MongoHostname, MongoPort.ToString())
-			: string.Format("{0}:{1}@{2}:{3}", EncodedUsername, EncodedPassword, MongoHostname, MongoPort.ToString());
+			? string.Format("{0}:{1}", MongoHostname, MongoPort)
+			: string.Format("{0}:{1}@{2}:{3}", EncodedUsername, EncodedPassword, MongoHostname, MongoPort);
 
 		private string QueueDirectory { get; set; }
 

--- a/src/LfMerge.Core/Settings/LfMergeSettings.cs
+++ b/src/LfMerge.Core/Settings/LfMergeSettings.cs
@@ -38,7 +38,7 @@ namespace LfMerge.Core.Settings
 
 		private string _mongoPort;
 		public string MongoPort {
-			get => Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort) ?? DefaultLfMergeSettings.MongoPort.ToString();
+			get => _mongoPort ?? Environment.GetEnvironmentVariable(MagicStrings.SettingsEnvVar_MongoPort) ?? DefaultLfMergeSettings.MongoPort.ToString();
 			set => _mongoPort = value;
 		}
 


### PR DESCRIPTION
Fixes #345.

The end-to-end LfMerge tests now use a real MongoDB container (spun up and torn down for each test, with no data persistence) rather than a mock Mongo connection. This does require the presence of Docker on the machine running the E2E tests, so that `docker run mongo:6` will succeed.