### PR TITLE
Fix bug with too-long substrings

### DIFF
--- a/src/LfMerge.Core/Reporting/ConversionError.cs
+++ b/src/LfMerge.Core/Reporting/ConversionError.cs
@@ -118,7 +118,8 @@ namespace LfMerge.Core.Reporting
 		}
 
 		public string Label() {
-			if (Comment == null || Comment.Content == null) return string.Empty;
+			if (Comment == null || String.IsNullOrEmpty(Comment.Content)) return string.Empty;
+			if (Comment.Content.Length < 100) return Comment.Content;
 			return Comment.Content.Substring(0, 100);
 		}
 	}


### PR DESCRIPTION
I assumed that `string.Substring(0, 100)` was safe and that on a string of less than 100 characters it would just return the unmodified string. That would be the sensible thing to do — but the C# API loves to throw exceptions instead of doing the sensible thing. So we need to check the length ourselves before calling `string.Substring`.