### PR TITLE
Use chg rather than hg for Send/Receive, saving about 20 seconds per S/R

### DIFF
--- a/docker/scripts/create-installation-tarball.sh
+++ b/docker/scripts/create-installation-tarball.sh
@@ -75,6 +75,7 @@ install -d ${DBDESTDIR}/${LIB}/Mercurial/mercurial/utils
 install -d ${DBDESTDIR}/${LIB}/Mercurial/mercurial/upgrade_utils
 install -d ${DBDESTDIR}/${LIB}/MercurialExtensions
 install -d ${DBDESTDIR}/${LIB}/MercurialExtensions/fixutf8
+install -m 755 Mercurial/chg ${DBDESTDIR}/${LIB}/Mercurial
 install -m 755 Mercurial/hg ${DBDESTDIR}/${LIB}/Mercurial
 install -m 644 Mercurial/mercurial.ini ${DBDESTDIR}/${LIB}/Mercurial
 install -m 644 Mercurial/hgdemandimport/*.* ${DBDESTDIR}/${LIB}/Mercurial/hgdemandimport

--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -5,6 +5,6 @@
 
 while :
 do
-  sudo -H -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
   sleep 86400
 done

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -10,7 +10,7 @@ trap "exit" TERM
 # This is expected to run as the CMD, launched by the entry point.
 
 while inotifywait -e close_write /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
-  sudo -H -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
   # Run it again just to ensure that any initial clones that missed a race condition have a chance to get noticed
-  sudo -H -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
 done

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -94,42 +94,6 @@ namespace LfMerge.Core.Tests.Actions
 		}
 
 		[Test]
-		public void MissingFwDataFixer_Throws()
-		{
-			// This used to just change the current directory, which was enough when LfMergeBridge only
-			// looked for FixFwData in the current directory. However, LfMergeBridge is now smart enough
-			// to look for FixFwData in the folder where LfMergeBridge.dll is being run from, which finds
-			// it no matter the current working directory. So we need to move it out of the way, and ensure
-			// that it gets moved back at the end of the test so other tests don't start failing.
-
-			string fixFwDataPath = null;
-			string fixFwDataExePath = null;
-			try {
-				// Setup
-				var assembly = typeof(LfMergeBridge.LfMergeBridge).Assembly;
-				var dir = Directory.GetParent(assembly.Location).FullName;
-				if (File.Exists(Path.Join(dir, "FixFwData"))) {
-					fixFwDataPath = Path.Join(dir, "FixFwData");
-					File.Move(fixFwDataPath, fixFwDataPath + ".renamed");
-				}
-				if (File.Exists(Path.Join(dir, "FixFwData.exe"))) {
-					fixFwDataExePath = Path.Join(dir, "FixFwData.exe");
-					File.Move(fixFwDataExePath, fixFwDataExePath + ".renamed");
-				}
-
-				// Execute/Verify
-				Assert.That(() => _synchronizeAction.Run(_lfProject),
-					// This can't happen in real life because we ensure that we have a clone
-					// before we call sync. Therefore it is acceptable to get an exception.
-					Throws.TypeOf<InvalidOperationException>());
-
-			} finally {
-				if (fixFwDataPath != null) File.Move(fixFwDataPath + ".renamed", fixFwDataPath);
-				if (fixFwDataExePath != null) File.Move(fixFwDataExePath + ".renamed", fixFwDataExePath);
-			}
-		}
-
-		[Test]
 		public void Error_NoHgRepo()
 		{
 			// Setup

--- a/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
+++ b/src/LfMerge.Core.Tests/Actions/SynchronizeActionBridgeIntegrationTests.cs
@@ -96,16 +96,37 @@ namespace LfMerge.Core.Tests.Actions
 		[Test]
 		public void MissingFwDataFixer_Throws()
 		{
-			// Setup
-			var tmpFolder = Path.Combine(_languageDepotFolder.Path, "WorkDir");
-			Directory.CreateDirectory(tmpFolder);
-			Directory.SetCurrentDirectory(tmpFolder);
+			// This used to just change the current directory, which was enough when LfMergeBridge only
+			// looked for FixFwData in the current directory. However, LfMergeBridge is now smart enough
+			// to look for FixFwData in the folder where LfMergeBridge.dll is being run from, which finds
+			// it no matter the current working directory. So we need to move it out of the way, and ensure
+			// that it gets moved back at the end of the test so other tests don't start failing.
 
-			// Execute/Verify
-			Assert.That(() => _synchronizeAction.Run(_lfProject),
-				// This can't happen in real life because we ensure that we have a clone
-				// before we call sync. Therefore it is acceptable to get an exception.
-				Throws.TypeOf<InvalidOperationException>());
+			string fixFwDataPath = null;
+			string fixFwDataExePath = null;
+			try {
+				// Setup
+				var assembly = typeof(LfMergeBridge.LfMergeBridge).Assembly;
+				var dir = Directory.GetParent(assembly.Location).FullName;
+				if (File.Exists(Path.Join(dir, "FixFwData"))) {
+					fixFwDataPath = Path.Join(dir, "FixFwData");
+					File.Move(fixFwDataPath, fixFwDataPath + ".renamed");
+				}
+				if (File.Exists(Path.Join(dir, "FixFwData.exe"))) {
+					fixFwDataExePath = Path.Join(dir, "FixFwData.exe");
+					File.Move(fixFwDataExePath, fixFwDataExePath + ".renamed");
+				}
+
+				// Execute/Verify
+				Assert.That(() => _synchronizeAction.Run(_lfProject),
+					// This can't happen in real life because we ensure that we have a clone
+					// before we call sync. Therefore it is acceptable to get an exception.
+					Throws.TypeOf<InvalidOperationException>());
+
+			} finally {
+				if (fixFwDataPath != null) File.Move(fixFwDataPath + ".renamed", fixFwDataPath);
+				if (fixFwDataExePath != null) File.Move(fixFwDataExePath + ".renamed", fixFwDataExePath);
+			}
 		}
 
 		[Test]

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -43,7 +43,7 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
     <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" PrivateAssets="All" />
     <PackageReference Include="SIL.Chorus.ChorusMerge" Version="6.0.0-beta0055" GeneratePathProperty="true" />
-    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta*" />
+    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028" />
     <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0055" />
     <PackageReference Include="SIL.Core.Desktop" Version="12.0.0" />
     <PackageReference Include="SIL.LCModel" Version="11.0.0-beta0077" />

--- a/src/LfMerge.Core/LfMerge.Core.csproj
+++ b/src/LfMerge.Core/LfMerge.Core.csproj
@@ -41,10 +41,10 @@ See full changelog at https://github.com/sillsdev/LfMerge/blob/develop/CHANGELOG
     <PackageReference Include="MongoDB.Driver.Core.signed" Version="2.13.*" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="SIL.Bugsnag.Signed" Version="2.2.1" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.*" PrivateAssets="All" />
-    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="6.0.0-*" GeneratePathProperty="true" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" PrivateAssets="All" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" Version="6.0.0-beta0055" GeneratePathProperty="true" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta*" />
-    <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-*" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0055" />
     <PackageReference Include="SIL.Core.Desktop" Version="12.0.0" />
     <PackageReference Include="SIL.LCModel" Version="11.0.0-beta0077" />
     <PackageReference Include="SIL.LCModel.Core" Version="11.0.0-beta0077" GeneratePathProperty="true" />

--- a/src/LfMerge/Program.cs
+++ b/src/LfMerge/Program.cs
@@ -40,6 +40,9 @@ namespace LfMerge
 			MainClass.Logger.Notice("LfMerge {2} (database {0}) starting with args: {1}",
 				MainClass.ModelVersion, string.Join(" ", args), MainClass.GetVersionInfo("SemVer"));
 
+			// chg internal logic for finding hg trips up on LfMerge's unconvential path to hg, so we need to tell it where to find hg
+			Environment.SetEnvironmentVariable("CHGHG", $"/usr/lib/lfmerge/{MainClass.ModelVersion}/Mercurial/hg");
+
 			if (string.IsNullOrEmpty(options.ProjectCode))
 			{
 				MainClass.Logger.Error("Command line doesn't contain project code - exiting.");

--- a/src/LfMergeQueueManager/QueueManager.cs
+++ b/src/LfMergeQueueManager/QueueManager.cs
@@ -27,7 +27,7 @@ namespace LfMerge.QueueManager
 			if (options == null)
 				return;
 
-			MainClass.Logger.Notice("LfMergeQueueManager starting with args: {0}", string.Join(" ", args));
+			MainClass.Logger.Notice("LfMergeQueueManager starting with CHORUS_HG_EXE value \"{1}\" and args: {0}", string.Join(" ", args), Environment.GetEnvironmentVariable("CHORUS_HG_EXE") ?? "<null>");
 
 			// initialize the SLDR
 			Sldr.Initialize();


### PR DESCRIPTION
Will allow speeding up Send/Receive operations by setting the CHORUS_HG_EXE environment variable.

We also need to update one unit test that is now broken because of a change in LfMergeBridge's logic for finding FixFwData. LfMergeBridge used to look for FixFwData in the current working directory *only*, which made it rather brittle as you had to cd into the right folder before running lfmerge. Now we've improved the logic for finding FixFwData so it's much less brittle. Which means that the test that checks what LfMergeBridge will do when FixFwData is missing, which used to simply cd to an empty directory, now has to do a lot more work to get LfMergeBridge to throw an exception.

Fixes #352.