### PR TITLE
Use chg in GitHub Actions tests

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -74,6 +74,7 @@ jobs:
           source environ
           dotnet test -l:"console;verbosity=normal" -l:nunit -c Release
         env:
+          CHORUS_HG_EXE: chg
           BUILD_NUMBER: ${{ github.run_number }}
           DbVersion: ${{ matrix.dbversion }}
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: "30000"


### PR DESCRIPTION
Should speed testing up by a minute or two.

Fixes #354.