### PR TITLE
Increase Chorus merge timeout to 60 minutes

### DIFF
--- a/environ
+++ b/environ
@@ -9,3 +9,6 @@ export PATH="${BASE}/output/${BUILD}/net8.0:${BASE}/output/Mercurial:${PATH}"
 # set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
 # incompatible with our version of Mercurial
 export HGRCPATH=/etc/mercurial/hgrc
+
+# Increase Chorus timeout to 60 minutes since some projects take longer than 15 minutes to merge
+export CHORUS_LOCAL_TIMEOUT_SECONDS=3600


### PR DESCRIPTION
At least one project took 23 minutes 3 seconds to do an hg merge operation, so Chorus's default 15 minute timeout is too low.

Fixes #357.