### PR TITLE
Raise default Chorus local-op timeout so large projects can Send/Receive

### DIFF
--- a/environ
+++ b/environ
@@ -9,3 +9,9 @@ export PATH="${BASE}/output/${BUILD}/net8.0:${BASE}/output/Mercurial:${PATH}"
 # set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
 # incompatible with our version of Mercurial
 export HGRCPATH=/etc/mercurial/hgrc
+
+# Chorus's 15-min default timeout on local hg ops is too short for very large
+# projects, whose merge commits can exceed it and land the project on hold
+# (https://github.com/sillsdev/LfMerge/issues/357). Overridable per deployment via
+# CHORUS_LOCAL_TIMEOUT_SECONDS, passed through by the launch scripts' --preserve-env.
+export CHORUS_LOCAL_TIMEOUT_SECONDS=${CHORUS_LOCAL_TIMEOUT_SECONDS:-1800}

--- a/lfmergeqm-background.sh
+++ b/lfmergeqm-background.sh
@@ -5,6 +5,6 @@
 
 while :
 do
-  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE,CHORUS_LOCAL_TIMEOUT_SECONDS -u www-data lfmergeqm
   sleep 86400
 done

--- a/lfmergeqm-looping.sh
+++ b/lfmergeqm-looping.sh
@@ -10,7 +10,7 @@ trap "exit" TERM
 # This is expected to run as the CMD, launched by the entry point.
 
 while inotifywait -e close_write /var/lib/languageforge/lexicon/sendreceive/syncqueue; do
-  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE,CHORUS_LOCAL_TIMEOUT_SECONDS -u www-data lfmergeqm
   # Run it again just to ensure that any initial clones that missed a race condition have a chance to get noticed
-  sudo -H --preserve-env=CHORUS_HG_EXE -u www-data lfmergeqm
+  sudo -H --preserve-env=CHORUS_HG_EXE,CHORUS_LOCAL_TIMEOUT_SECONDS -u www-data lfmergeqm
 done


### PR DESCRIPTION
Chorus's default 15-minute timeout on local hg operations (notably the post-merge `hg commit`) is too short for very large projects: the commit runs past 900s and the project lands on hold with a `TimeoutException`. This recurs for at least one production project (#357), where a maintainer has had to hand-edit `environ` on the live container — which is wiped on every redeploy.

This bakes the fix into the image:
- `environ`: default `CHORUS_LOCAL_TIMEOUT_SECONDS` to 1800 (30 min) via `${VAR:-1800}` — a conservative default that a deployment can raise as needed.
- `lfmergeqm-background.sh` / `lfmergeqm-looping.sh`: add `CHORUS_LOCAL_TIMEOUT_SECONDS` to the `sudo --preserve-env` list, so a deployment-supplied value survives the privilege drop to `www-data` and overrides the default. Without this, an env var set on the container is stripped by sudo and never reaches Chorus.

Closes #357.
